### PR TITLE
Adjust service return and handle the data coming from the request

### DIFF
--- a/weni/billing/services.py
+++ b/weni/billing/services.py
@@ -6,19 +6,23 @@ from weni.billing.serializers import BillingRequestSerializer, ActiveContactDeta
 
 class BillingService(generics.GenericService):
     def Total(self, request, context):
-        serializer = BillingRequestSerializer(message=request)
-        if serializer.is_valid():
-            org_uuid = serializer.validated_data["org_uuid"]
-            before = serializer.validated_data["before"]
-            after = serializer.validated_data["after"]
-            total_count = Query.total(org_uuid, before, after)
-            return BillingResponse(active_contacts=total_count)
+        serializer = BillingRequestSerializer(
+            data=dict(org_uuid=request.org_uuid, before=request.before.ToDatetime(), after=request.after.ToDatetime())
+        )
+        serializer.is_valid(raise_exception=True)
+        org_uuid = serializer.validated_data["org_uuid"]
+        before = serializer.validated_data["before"]
+        after = serializer.validated_data["after"]
+        total_count = Query.total(org_uuid, before, after)
+        return BillingResponse(active_contacts=total_count)
 
     def Detailed(self, request, context):
-        serializer = BillingRequestSerializer(message=request)
-        if serializer.is_valid():
-            org_uuid = serializer.validated_data["org_uuid"]
-            before = serializer.validated_data["before"]
-            after = serializer.validated_data["after"]
-            results = Query.detailed(org_uuid, before, after)
-            return ActiveContactDetailSerializer(results, many=True).message
+        serializer = BillingRequestSerializer(
+            data=dict(org_uuid=request.org_uuid, before=request.before.ToDatetime(), after=request.after.ToDatetime())
+        )
+        serializer.is_valid(raise_exception=True)
+        org_uuid = serializer.validated_data["org_uuid"]
+        before = serializer.validated_data["before"]
+        after = serializer.validated_data["after"]
+        results = Query.detailed(org_uuid, before, after)
+        return ActiveContactDetailSerializer(results, many=True).message


### PR DESCRIPTION
This pull request aims to fix 2 problems:
1 - When sending invalid data in the request we had a return equal to `None`.
- Resolution: Added a `raise_exception=True` to `serializer.is_valid()` so if the data sent is invalid an exception will be raised instead of returning `None`  

2 - `BillingRequestSerializer` was unable to interpret the type of data being sent in `after` and `before`.
- Resolution: Both fields were converted to `datetime` before being sent to the serializer.