### PR TITLE
Adjust Org user_email and update return

### DIFF
--- a/weni/grpc/org/grpc_gen/org_pb2.py
+++ b/weni/grpc/org/grpc_gen/org_pb2.py
@@ -15,12 +15,12 @@ from google.protobuf import empty_pb2 as google_dot_protobuf_dot_empty__pb2
 
 
 DESCRIPTOR = _descriptor.FileDescriptor(
-  name='weni/grpc.org/grpc_gen/org.proto',
+  name='weni/grpc/org/grpc_gen/org.proto',
   package='weni.rapidpro.org',
   syntax='proto3',
   serialized_options=None,
   create_key=_descriptor._internal_create_key,
-  serialized_pb=b'\n weni/grpc.org/grpc_gen/org.proto\x12\x11weni.rapidpro.org\x1a\x1bgoogle/protobuf/empty.proto\"|\n\x03Org\x12\n\n\x02id\x18\x01 \x01(\x05\x12\x0c\n\x04name\x18\x02 \x01(\t\x12\x0c\n\x04uuid\x18\x03 \x01(\t\x12\x10\n\x08timezone\x18\x04 \x01(\t\x12\x13\n\x0b\x64\x61te_format\x18\x05 \x01(\t\x12&\n\x05users\x18\x06 \x03(\x0b\x32\x17.weni.rapidpro.org.User\"Z\n\x04User\x12\n\n\x02id\x18\x01 \x01(\x05\x12\r\n\x05\x65mail\x18\x02 \x01(\t\x12\x10\n\x08username\x18\x03 \x01(\t\x12\x12\n\nfirst_name\x18\x04 \x01(\t\x12\x11\n\tlast_name\x18\x05 \x01(\t\"$\n\x0eOrgListRequest\x12\x12\n\nuser_email\x18\x01 \x01(\t\"F\n\x10OrgCreateRequest\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x10\n\x08timezone\x18\x02 \x01(\t\x12\x12\n\nuser_email\x18\x03 \x01(\t\"\"\n\x12OrgRetrieveRequest\x12\x0c\n\x04uuid\x18\x01 \x01(\t\"5\n\x11OrgDestroyRequest\x12\x0c\n\x04uuid\x18\x01 \x01(\t\x12\x12\n\nuser_email\x18\x02 \x01(\t\"\xa4\x03\n\x10OrgUpdateRequest\x12\x0c\n\x04uuid\x18\x01 \x01(\t\x12\x12\n\nuser_email\x18\x02 \x01(\t\x12\x11\n\x04name\x18\x03 \x01(\tH\x00\x88\x01\x01\x12\x15\n\x08timezone\x18\x04 \x01(\tH\x01\x88\x01\x01\x12\x18\n\x0b\x64\x61te_format\x18\x05 \x01(\tH\x02\x88\x01\x01\x12\x11\n\x04plan\x18\x06 \x01(\tH\x03\x88\x01\x01\x12\x15\n\x08plan_end\x18\x07 \x01(\tH\x04\x88\x01\x01\x12\x12\n\x05\x62rand\x18\x08 \x01(\tH\x05\x88\x01\x01\x12\x14\n\x07is_anon\x18\t \x01(\x08H\x06\x88\x01\x01\x12\x1a\n\ris_multi_user\x18\n \x01(\x08H\x07\x88\x01\x01\x12\x19\n\x0cis_multi_org\x18\x0b \x01(\x08H\x08\x88\x01\x01\x12\x19\n\x0cis_suspended\x18\x0c \x01(\x08H\t\x88\x01\x01\x42\x07\n\x05_nameB\x0b\n\t_timezoneB\x0e\n\x0c_date_formatB\x07\n\x05_planB\x0b\n\t_plan_endB\x08\n\x06_brandB\n\n\x08_is_anonB\x10\n\x0e_is_multi_userB\x0f\n\r_is_multi_orgB\x0f\n\r_is_suspended2\x8d\x03\n\rOrgController\x12\x45\n\x04List\x12!.weni.rapidpro.org.OrgListRequest\x1a\x16.weni.rapidpro.org.Org\"\x00\x30\x01\x12G\n\x06\x43reate\x12#.weni.rapidpro.org.OrgCreateRequest\x1a\x16.weni.rapidpro.org.Org\"\x00\x12K\n\x08Retrieve\x12%.weni.rapidpro.org.OrgRetrieveRequest\x1a\x16.weni.rapidpro.org.Org\"\x00\x12T\n\x06Update\x12#.weni.rapidpro.org.OrgUpdateRequest\x1a#.weni.rapidpro.org.OrgUpdateRequest\"\x00\x12I\n\x07\x44\x65stroy\x12$.weni.rapidpro.org.OrgDestroyRequest\x1a\x16.google.protobuf.Empty\"\x00\x62\x06proto3'
+  serialized_pb=b'\n weni/grpc/org/grpc_gen/org.proto\x12\x11weni.rapidpro.org\x1a\x1bgoogle/protobuf/empty.proto\"|\n\x03Org\x12\n\n\x02id\x18\x01 \x01(\x05\x12\x0c\n\x04name\x18\x02 \x01(\t\x12\x0c\n\x04uuid\x18\x03 \x01(\t\x12\x10\n\x08timezone\x18\x04 \x01(\t\x12\x13\n\x0b\x64\x61te_format\x18\x05 \x01(\t\x12&\n\x05users\x18\x06 \x03(\x0b\x32\x17.weni.rapidpro.org.User\"Z\n\x04User\x12\n\n\x02id\x18\x01 \x01(\x05\x12\r\n\x05\x65mail\x18\x02 \x01(\t\x12\x10\n\x08username\x18\x03 \x01(\t\x12\x12\n\nfirst_name\x18\x04 \x01(\t\x12\x11\n\tlast_name\x18\x05 \x01(\t\"$\n\x0eOrgListRequest\x12\x12\n\nuser_email\x18\x01 \x01(\t\"F\n\x10OrgCreateRequest\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x10\n\x08timezone\x18\x02 \x01(\t\x12\x12\n\nuser_email\x18\x03 \x01(\t\"\"\n\x12OrgRetrieveRequest\x12\x0c\n\x04uuid\x18\x01 \x01(\t\"5\n\x11OrgDestroyRequest\x12\x0c\n\x04uuid\x18\x01 \x01(\t\x12\x12\n\nuser_email\x18\x02 \x01(\t\"\xba\x03\n\x10OrgUpdateRequest\x12\x0c\n\x04uuid\x18\x01 \x01(\t\x12\x18\n\x0bmodified_by\x18\x02 \x01(\tH\x00\x88\x01\x01\x12\x11\n\x04name\x18\x03 \x01(\tH\x01\x88\x01\x01\x12\x15\n\x08timezone\x18\x04 \x01(\tH\x02\x88\x01\x01\x12\x18\n\x0b\x64\x61te_format\x18\x05 \x01(\tH\x03\x88\x01\x01\x12\x11\n\x04plan\x18\x06 \x01(\tH\x04\x88\x01\x01\x12\x15\n\x08plan_end\x18\x07 \x01(\tH\x05\x88\x01\x01\x12\x12\n\x05\x62rand\x18\x08 \x01(\tH\x06\x88\x01\x01\x12\x14\n\x07is_anon\x18\t \x01(\x08H\x07\x88\x01\x01\x12\x1a\n\ris_multi_user\x18\n \x01(\x08H\x08\x88\x01\x01\x12\x19\n\x0cis_multi_org\x18\x0b \x01(\x08H\t\x88\x01\x01\x12\x19\n\x0cis_suspended\x18\x0c \x01(\x08H\n\x88\x01\x01\x42\x0e\n\x0c_modified_byB\x07\n\x05_nameB\x0b\n\t_timezoneB\x0e\n\x0c_date_formatB\x07\n\x05_planB\x0b\n\t_plan_endB\x08\n\x06_brandB\n\n\x08_is_anonB\x10\n\x0e_is_multi_userB\x0f\n\r_is_multi_orgB\x0f\n\r_is_suspended2\x80\x03\n\rOrgController\x12\x45\n\x04List\x12!.weni.rapidpro.org.OrgListRequest\x1a\x16.weni.rapidpro.org.Org\"\x00\x30\x01\x12G\n\x06\x43reate\x12#.weni.rapidpro.org.OrgCreateRequest\x1a\x16.weni.rapidpro.org.Org\"\x00\x12K\n\x08Retrieve\x12%.weni.rapidpro.org.OrgRetrieveRequest\x1a\x16.weni.rapidpro.org.Org\"\x00\x12G\n\x06Update\x12#.weni.rapidpro.org.OrgUpdateRequest\x1a\x16.weni.rapidpro.org.Org\"\x00\x12I\n\x07\x44\x65stroy\x12$.weni.rapidpro.org.OrgDestroyRequest\x1a\x16.google.protobuf.Empty\"\x00\x62\x06proto3'
   ,
   dependencies=[google_dot_protobuf_dot_empty__pb2.DESCRIPTOR,])
 
@@ -319,7 +319,7 @@ _ORGUPDATEREQUEST = _descriptor.Descriptor(
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
     _descriptor.FieldDescriptor(
-      name='user_email', full_name='weni.rapidpro.org.OrgUpdateRequest.user_email', index=1,
+      name='modified_by', full_name='weni.rapidpro.org.OrgUpdateRequest.modified_by', index=1,
       number=2, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=b"".decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
@@ -407,61 +407,69 @@ _ORGUPDATEREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
     _descriptor.OneofDescriptor(
-      name='_name', full_name='weni.rapidpro.org.OrgUpdateRequest._name',
+      name='_modified_by', full_name='weni.rapidpro.org.OrgUpdateRequest._modified_by',
       index=0, containing_type=None,
       create_key=_descriptor._internal_create_key,
     fields=[]),
     _descriptor.OneofDescriptor(
-      name='_timezone', full_name='weni.rapidpro.org.OrgUpdateRequest._timezone',
+      name='_name', full_name='weni.rapidpro.org.OrgUpdateRequest._name',
       index=1, containing_type=None,
       create_key=_descriptor._internal_create_key,
     fields=[]),
     _descriptor.OneofDescriptor(
-      name='_date_format', full_name='weni.rapidpro.org.OrgUpdateRequest._date_format',
+      name='_timezone', full_name='weni.rapidpro.org.OrgUpdateRequest._timezone',
       index=2, containing_type=None,
       create_key=_descriptor._internal_create_key,
     fields=[]),
     _descriptor.OneofDescriptor(
-      name='_plan', full_name='weni.rapidpro.org.OrgUpdateRequest._plan',
+      name='_date_format', full_name='weni.rapidpro.org.OrgUpdateRequest._date_format',
       index=3, containing_type=None,
       create_key=_descriptor._internal_create_key,
     fields=[]),
     _descriptor.OneofDescriptor(
-      name='_plan_end', full_name='weni.rapidpro.org.OrgUpdateRequest._plan_end',
+      name='_plan', full_name='weni.rapidpro.org.OrgUpdateRequest._plan',
       index=4, containing_type=None,
       create_key=_descriptor._internal_create_key,
     fields=[]),
     _descriptor.OneofDescriptor(
-      name='_brand', full_name='weni.rapidpro.org.OrgUpdateRequest._brand',
+      name='_plan_end', full_name='weni.rapidpro.org.OrgUpdateRequest._plan_end',
       index=5, containing_type=None,
       create_key=_descriptor._internal_create_key,
     fields=[]),
     _descriptor.OneofDescriptor(
-      name='_is_anon', full_name='weni.rapidpro.org.OrgUpdateRequest._is_anon',
+      name='_brand', full_name='weni.rapidpro.org.OrgUpdateRequest._brand',
       index=6, containing_type=None,
       create_key=_descriptor._internal_create_key,
     fields=[]),
     _descriptor.OneofDescriptor(
-      name='_is_multi_user', full_name='weni.rapidpro.org.OrgUpdateRequest._is_multi_user',
+      name='_is_anon', full_name='weni.rapidpro.org.OrgUpdateRequest._is_anon',
       index=7, containing_type=None,
       create_key=_descriptor._internal_create_key,
     fields=[]),
     _descriptor.OneofDescriptor(
-      name='_is_multi_org', full_name='weni.rapidpro.org.OrgUpdateRequest._is_multi_org',
+      name='_is_multi_user', full_name='weni.rapidpro.org.OrgUpdateRequest._is_multi_user',
       index=8, containing_type=None,
       create_key=_descriptor._internal_create_key,
     fields=[]),
     _descriptor.OneofDescriptor(
-      name='_is_suspended', full_name='weni.rapidpro.org.OrgUpdateRequest._is_suspended',
+      name='_is_multi_org', full_name='weni.rapidpro.org.OrgUpdateRequest._is_multi_org',
       index=9, containing_type=None,
+      create_key=_descriptor._internal_create_key,
+    fields=[]),
+    _descriptor.OneofDescriptor(
+      name='_is_suspended', full_name='weni.rapidpro.org.OrgUpdateRequest._is_suspended',
+      index=10, containing_type=None,
       create_key=_descriptor._internal_create_key,
     fields=[]),
   ],
   serialized_start=504,
-  serialized_end=924,
+  serialized_end=946,
 )
 
 _ORG.fields_by_name['users'].message_type = _USER
+_ORGUPDATEREQUEST.oneofs_by_name['_modified_by'].fields.append(
+  _ORGUPDATEREQUEST.fields_by_name['modified_by'])
+_ORGUPDATEREQUEST.fields_by_name['modified_by'].containing_oneof = _ORGUPDATEREQUEST.oneofs_by_name['_modified_by']
 _ORGUPDATEREQUEST.oneofs_by_name['_name'].fields.append(
   _ORGUPDATEREQUEST.fields_by_name['name'])
 _ORGUPDATEREQUEST.fields_by_name['name'].containing_oneof = _ORGUPDATEREQUEST.oneofs_by_name['_name']
@@ -559,8 +567,8 @@ _ORGCONTROLLER = _descriptor.ServiceDescriptor(
   index=0,
   serialized_options=None,
   create_key=_descriptor._internal_create_key,
-  serialized_start=927,
-  serialized_end=1324,
+  serialized_start=949,
+  serialized_end=1333,
   methods=[
   _descriptor.MethodDescriptor(
     name='List',
@@ -598,7 +606,7 @@ _ORGCONTROLLER = _descriptor.ServiceDescriptor(
     index=3,
     containing_service=None,
     input_type=_ORGUPDATEREQUEST,
-    output_type=_ORGUPDATEREQUEST,
+    output_type=_ORG,
     serialized_options=None,
     create_key=_descriptor._internal_create_key,
   ),

--- a/weni/grpc/org/grpc_gen/org_pb2_grpc.py
+++ b/weni/grpc/org/grpc_gen/org_pb2_grpc.py
@@ -3,7 +3,7 @@
 import grpc
 
 from google.protobuf import empty_pb2 as google_dot_protobuf_dot_empty__pb2
-from weni.grpc.org.grpc_gen import org_pb2 as weni_dot_org__grpc_dot_grpc__gen_dot_org__pb2
+from weni.grpc.org.grpc_gen import org_pb2 as weni_dot_grpc_dot_org_dot_grpc__gen_dot_org__pb2
 
 
 class OrgControllerStub(object):
@@ -17,27 +17,27 @@ class OrgControllerStub(object):
         """
         self.List = channel.unary_stream(
                 '/weni.rapidpro.org.OrgController/List',
-                request_serializer=weni_dot_org__grpc_dot_grpc__gen_dot_org__pb2.OrgListRequest.SerializeToString,
-                response_deserializer=weni_dot_org__grpc_dot_grpc__gen_dot_org__pb2.Org.FromString,
+                request_serializer=weni_dot_grpc_dot_org_dot_grpc__gen_dot_org__pb2.OrgListRequest.SerializeToString,
+                response_deserializer=weni_dot_grpc_dot_org_dot_grpc__gen_dot_org__pb2.Org.FromString,
                 )
         self.Create = channel.unary_unary(
                 '/weni.rapidpro.org.OrgController/Create',
-                request_serializer=weni_dot_org__grpc_dot_grpc__gen_dot_org__pb2.OrgCreateRequest.SerializeToString,
-                response_deserializer=weni_dot_org__grpc_dot_grpc__gen_dot_org__pb2.Org.FromString,
+                request_serializer=weni_dot_grpc_dot_org_dot_grpc__gen_dot_org__pb2.OrgCreateRequest.SerializeToString,
+                response_deserializer=weni_dot_grpc_dot_org_dot_grpc__gen_dot_org__pb2.Org.FromString,
                 )
         self.Retrieve = channel.unary_unary(
                 '/weni.rapidpro.org.OrgController/Retrieve',
-                request_serializer=weni_dot_org__grpc_dot_grpc__gen_dot_org__pb2.OrgRetrieveRequest.SerializeToString,
-                response_deserializer=weni_dot_org__grpc_dot_grpc__gen_dot_org__pb2.Org.FromString,
+                request_serializer=weni_dot_grpc_dot_org_dot_grpc__gen_dot_org__pb2.OrgRetrieveRequest.SerializeToString,
+                response_deserializer=weni_dot_grpc_dot_org_dot_grpc__gen_dot_org__pb2.Org.FromString,
                 )
         self.Update = channel.unary_unary(
                 '/weni.rapidpro.org.OrgController/Update',
-                request_serializer=weni_dot_org__grpc_dot_grpc__gen_dot_org__pb2.OrgUpdateRequest.SerializeToString,
-                response_deserializer=weni_dot_org__grpc_dot_grpc__gen_dot_org__pb2.OrgUpdateRequest.FromString,
+                request_serializer=weni_dot_grpc_dot_org_dot_grpc__gen_dot_org__pb2.OrgUpdateRequest.SerializeToString,
+                response_deserializer=weni_dot_grpc_dot_org_dot_grpc__gen_dot_org__pb2.Org.FromString,
                 )
         self.Destroy = channel.unary_unary(
                 '/weni.rapidpro.org.OrgController/Destroy',
-                request_serializer=weni_dot_org__grpc_dot_grpc__gen_dot_org__pb2.OrgDestroyRequest.SerializeToString,
+                request_serializer=weni_dot_grpc_dot_org_dot_grpc__gen_dot_org__pb2.OrgDestroyRequest.SerializeToString,
                 response_deserializer=google_dot_protobuf_dot_empty__pb2.Empty.FromString,
                 )
 
@@ -80,27 +80,27 @@ def add_OrgControllerServicer_to_server(servicer, server):
     rpc_method_handlers = {
             'List': grpc.unary_stream_rpc_method_handler(
                     servicer.List,
-                    request_deserializer=weni_dot_org__grpc_dot_grpc__gen_dot_org__pb2.OrgListRequest.FromString,
-                    response_serializer=weni_dot_org__grpc_dot_grpc__gen_dot_org__pb2.Org.SerializeToString,
+                    request_deserializer=weni_dot_grpc_dot_org_dot_grpc__gen_dot_org__pb2.OrgListRequest.FromString,
+                    response_serializer=weni_dot_grpc_dot_org_dot_grpc__gen_dot_org__pb2.Org.SerializeToString,
             ),
             'Create': grpc.unary_unary_rpc_method_handler(
                     servicer.Create,
-                    request_deserializer=weni_dot_org__grpc_dot_grpc__gen_dot_org__pb2.OrgCreateRequest.FromString,
-                    response_serializer=weni_dot_org__grpc_dot_grpc__gen_dot_org__pb2.Org.SerializeToString,
+                    request_deserializer=weni_dot_grpc_dot_org_dot_grpc__gen_dot_org__pb2.OrgCreateRequest.FromString,
+                    response_serializer=weni_dot_grpc_dot_org_dot_grpc__gen_dot_org__pb2.Org.SerializeToString,
             ),
             'Retrieve': grpc.unary_unary_rpc_method_handler(
                     servicer.Retrieve,
-                    request_deserializer=weni_dot_org__grpc_dot_grpc__gen_dot_org__pb2.OrgRetrieveRequest.FromString,
-                    response_serializer=weni_dot_org__grpc_dot_grpc__gen_dot_org__pb2.Org.SerializeToString,
+                    request_deserializer=weni_dot_grpc_dot_org_dot_grpc__gen_dot_org__pb2.OrgRetrieveRequest.FromString,
+                    response_serializer=weni_dot_grpc_dot_org_dot_grpc__gen_dot_org__pb2.Org.SerializeToString,
             ),
             'Update': grpc.unary_unary_rpc_method_handler(
                     servicer.Update,
-                    request_deserializer=weni_dot_org__grpc_dot_grpc__gen_dot_org__pb2.OrgUpdateRequest.FromString,
-                    response_serializer=weni_dot_org__grpc_dot_grpc__gen_dot_org__pb2.OrgUpdateRequest.SerializeToString,
+                    request_deserializer=weni_dot_grpc_dot_org_dot_grpc__gen_dot_org__pb2.OrgUpdateRequest.FromString,
+                    response_serializer=weni_dot_grpc_dot_org_dot_grpc__gen_dot_org__pb2.Org.SerializeToString,
             ),
             'Destroy': grpc.unary_unary_rpc_method_handler(
                     servicer.Destroy,
-                    request_deserializer=weni_dot_org__grpc_dot_grpc__gen_dot_org__pb2.OrgDestroyRequest.FromString,
+                    request_deserializer=weni_dot_grpc_dot_org_dot_grpc__gen_dot_org__pb2.OrgDestroyRequest.FromString,
                     response_serializer=google_dot_protobuf_dot_empty__pb2.Empty.SerializeToString,
             ),
     }
@@ -125,8 +125,8 @@ class OrgController(object):
             timeout=None,
             metadata=None):
         return grpc.experimental.unary_stream(request, target, '/weni.rapidpro.org.OrgController/List',
-            weni_dot_org__grpc_dot_grpc__gen_dot_org__pb2.OrgListRequest.SerializeToString,
-            weni_dot_org__grpc_dot_grpc__gen_dot_org__pb2.Org.FromString,
+            weni_dot_grpc_dot_org_dot_grpc__gen_dot_org__pb2.OrgListRequest.SerializeToString,
+            weni_dot_grpc_dot_org_dot_grpc__gen_dot_org__pb2.Org.FromString,
             options, channel_credentials,
             insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
 
@@ -142,8 +142,8 @@ class OrgController(object):
             timeout=None,
             metadata=None):
         return grpc.experimental.unary_unary(request, target, '/weni.rapidpro.org.OrgController/Create',
-            weni_dot_org__grpc_dot_grpc__gen_dot_org__pb2.OrgCreateRequest.SerializeToString,
-            weni_dot_org__grpc_dot_grpc__gen_dot_org__pb2.Org.FromString,
+            weni_dot_grpc_dot_org_dot_grpc__gen_dot_org__pb2.OrgCreateRequest.SerializeToString,
+            weni_dot_grpc_dot_org_dot_grpc__gen_dot_org__pb2.Org.FromString,
             options, channel_credentials,
             insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
 
@@ -159,8 +159,8 @@ class OrgController(object):
             timeout=None,
             metadata=None):
         return grpc.experimental.unary_unary(request, target, '/weni.rapidpro.org.OrgController/Retrieve',
-            weni_dot_org__grpc_dot_grpc__gen_dot_org__pb2.OrgRetrieveRequest.SerializeToString,
-            weni_dot_org__grpc_dot_grpc__gen_dot_org__pb2.Org.FromString,
+            weni_dot_grpc_dot_org_dot_grpc__gen_dot_org__pb2.OrgRetrieveRequest.SerializeToString,
+            weni_dot_grpc_dot_org_dot_grpc__gen_dot_org__pb2.Org.FromString,
             options, channel_credentials,
             insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
 
@@ -176,8 +176,8 @@ class OrgController(object):
             timeout=None,
             metadata=None):
         return grpc.experimental.unary_unary(request, target, '/weni.rapidpro.org.OrgController/Update',
-            weni_dot_org__grpc_dot_grpc__gen_dot_org__pb2.OrgUpdateRequest.SerializeToString,
-            weni_dot_org__grpc_dot_grpc__gen_dot_org__pb2.OrgUpdateRequest.FromString,
+            weni_dot_grpc_dot_org_dot_grpc__gen_dot_org__pb2.OrgUpdateRequest.SerializeToString,
+            weni_dot_grpc_dot_org_dot_grpc__gen_dot_org__pb2.Org.FromString,
             options, channel_credentials,
             insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
 
@@ -193,7 +193,7 @@ class OrgController(object):
             timeout=None,
             metadata=None):
         return grpc.experimental.unary_unary(request, target, '/weni.rapidpro.org.OrgController/Destroy',
-            weni_dot_org__grpc_dot_grpc__gen_dot_org__pb2.OrgDestroyRequest.SerializeToString,
+            weni_dot_grpc_dot_org_dot_grpc__gen_dot_org__pb2.OrgDestroyRequest.SerializeToString,
             google_dot_protobuf_dot_empty__pb2.Empty.FromString,
             options, channel_credentials,
             insecure, call_credentials, compression, wait_for_ready, timeout, metadata)

--- a/weni/grpc/org/serializers.py
+++ b/weni/grpc/org/serializers.py
@@ -2,6 +2,7 @@ from django_grpc_framework import proto_serializers
 from rest_framework import serializers
 
 from temba.orgs.models import Org
+from weni.grpc.core import serializers as weni_serializers
 from weni.grpc.org.grpc_gen import org_pb2
 
 
@@ -41,23 +42,18 @@ class OrgCreateProtoSerializer(proto_serializers.ModelProtoSerializer):
 
 class OrgUpdateProtoSerializer(proto_serializers.ModelProtoSerializer):
 
-    uuid = serializers.UUIDField()
-    user_email = serializers.EmailField()
+    uuid = serializers.CharField()
+    modified_by = weni_serializers.UserEmailRelatedField(required=False, write_only=True)
     timezone = serializers.CharField(required=False)
     name = serializers.CharField(required=False)
     plan_end = serializers.DateTimeField(required=False)
-
-    def validate_id(self, value):
-        SerializerUtils.get_object(Org, value)
-
-        return value
 
     class Meta:
         model = Org
         proto_class = org_pb2.Org
         fields = [
             "uuid",
-            "user_email",
+            "modified_by",
             "name",
             "timezone",
             "date_format",

--- a/weni/grpc/org/services.py
+++ b/weni/grpc/org/services.py
@@ -4,7 +4,6 @@ from django_grpc_framework import generics, mixins
 from google.protobuf import empty_pb2
 
 from temba.orgs.models import Org
-from weni.grpc.org.grpc_gen.org_pb2 import OrgUpdateRequest
 from weni.grpc.org.serializers import OrgCreateProtoSerializer, OrgProtoSerializer, OrgUpdateProtoSerializer
 from weni.grpc.core.services import AbstractService
 

--- a/weni/grpc/org/tests.py
+++ b/weni/grpc/org/tests.py
@@ -117,7 +117,7 @@ class OrgServiceTest(RPCTransactionTestCase):
 
         self.assertEquals(created_by, newuser)
         self.assertEquals(modified_by, newuser)
-        # self.assertFalse(org.uses_topups)
+        self.assertFalse(org.uses_topups)
 
         self.assertEquals(administrators.count(), 1)
         self.assertEquals(administrator, newuser)

--- a/weni/grpc/org/tests.py
+++ b/weni/grpc/org/tests.py
@@ -117,7 +117,7 @@ class OrgServiceTest(RPCTransactionTestCase):
 
         self.assertEquals(created_by, newuser)
         self.assertEquals(modified_by, newuser)
-        self.assertFalse(org.uses_topups)
+        # self.assertFalse(org.uses_topups)
 
         self.assertEquals(administrators.count(), 1)
         self.assertEquals(administrator, newuser)
@@ -184,10 +184,7 @@ class OrgServiceTest(RPCTransactionTestCase):
         permission_error_message = f"User: {user.id} has no permission to update Org: {org.uuid}"
 
         with self.assertRaisesMessage(FakeRpcError, permission_error_message):
-            self.stub.Update(org_pb2.OrgUpdateRequest(uuid=str(org.uuid), user_email=user.email))
-
-        with self.assertRaisesMessage(FakeRpcError, "User: None not found!"):
-            self.stub.Update(org_pb2.OrgUpdateRequest(uuid=str(org.uuid)))
+            self.stub.Update(org_pb2.OrgUpdateRequest(uuid=str(org.uuid), modified_by=user.email))
 
         user.is_superuser = True
         user.save()
@@ -207,7 +204,7 @@ class OrgServiceTest(RPCTransactionTestCase):
             "is_suspended": True,
         }
 
-        self.stub.Update(org_pb2.OrgUpdateRequest(uuid=str(org.uuid), user_email=user.email, **update_fields))
+        self.stub.Update(org_pb2.OrgUpdateRequest(uuid=str(org.uuid), modified_by=user.email, **update_fields))
 
         updated_org = Org.objects.get(pk=org.pk)
 


### PR DESCRIPTION
Main features:
- Remove the mandatory user_email field on Org update endpoint;
- Adjust Org update return.

Proto file PR: https://github.com/Ilhasoft/weni-protobuffers/pull/26
**Remember**, for this `Pull Request` to be approved, you must also approve that of [weni-protobuffers](https://github.com/Ilhasoft/weni-protobuffers/).