### PR TITLE
Adjust type of BillingRequest.before and BillingRequest.after

### DIFF
--- a/weni/grpc/billing/grpc_gen/billing_pb2.py
+++ b/weni/grpc/billing/grpc_gen/billing_pb2.py
@@ -17,17 +17,17 @@ from google.protobuf import timestamp_pb2 as google_dot_protobuf_dot_timestamp__
 
 DESCRIPTOR = _descriptor.FileDescriptor(
   name='weni/grpc/billing/grpc_gen/billing.proto',
-  package='weni.rapidpro.billing',
+  package='weni.flows.billing',
   syntax='proto3',
   serialized_options=None,
   create_key=_descriptor._internal_create_key,
-  serialized_pb=b'\n(weni/grpc/billing/grpc_gen/billing.proto\x12\x15weni.rapidpro.billing\x1a\x1fgoogle/protobuf/timestamp.proto\"y\n\x0e\x42illingRequest\x12\x10\n\x08org_uuid\x18\x01 \x01(\t\x12*\n\x06\x62\x65\x66ore\x18\x02 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12)\n\x05\x61\x66ter\x18\x03 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\"*\n\x0f\x42illingResponse\x12\x17\n\x0f\x61\x63tive_contacts\x18\x01 \x01(\x05\"\x83\x01\n\x03Msg\x12\x0c\n\x04uuid\x18\x01 \x01(\t\x12\x0c\n\x04text\x18\x02 \x01(\t\x12+\n\x07sent_on\x18\x03 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12\x33\n\tdirection\x18\x04 \x01(\x0e\x32 .weni.rapidpro.billing.Direction\"%\n\x07\x43hannel\x12\x0c\n\x04uuid\x18\x01 \x01(\t\x12\x0c\n\x04name\x18\x02 \x01(\t\"\x8b\x01\n\x13\x41\x63tiveContactDetail\x12\x0c\n\x04uuid\x18\x01 \x01(\t\x12\x0c\n\x04name\x18\x02 \x01(\t\x12\'\n\x03msg\x18\x03 \x01(\x0b\x32\x1a.weni.rapidpro.billing.Msg\x12/\n\x07\x63hannel\x18\x04 \x01(\x0b\x32\x1e.weni.rapidpro.billing.Channel*\"\n\tDirection\x12\t\n\x05INPUT\x10\x00\x12\n\n\x06OUTPUT\x10\x01\x32\xc6\x01\n\x07\x42illing\x12X\n\x05Total\x12%.weni.rapidpro.billing.BillingRequest\x1a&.weni.rapidpro.billing.BillingResponse\"\x00\x12\x61\n\x08\x44\x65tailed\x12%.weni.rapidpro.billing.BillingRequest\x1a*.weni.rapidpro.billing.ActiveContactDetail\"\x00\x30\x01\x62\x06proto3'
+  serialized_pb=b'\n(weni/grpc/billing/grpc_gen/billing.proto\x12\x12weni.flows.billing\x1a\x1fgoogle/protobuf/timestamp.proto\"A\n\x0e\x42illingRequest\x12\x10\n\x08org_uuid\x18\x01 \x01(\t\x12\x0e\n\x06\x62\x65\x66ore\x18\x02 \x01(\t\x12\r\n\x05\x61\x66ter\x18\x03 \x01(\t\"*\n\x0f\x42illingResponse\x12\x17\n\x0f\x61\x63tive_contacts\x18\x01 \x01(\x05\"\x80\x01\n\x03Msg\x12\x0c\n\x04uuid\x18\x01 \x01(\t\x12\x0c\n\x04text\x18\x02 \x01(\t\x12+\n\x07sent_on\x18\x03 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12\x30\n\tdirection\x18\x04 \x01(\x0e\x32\x1d.weni.flows.billing.Direction\"%\n\x07\x43hannel\x12\x0c\n\x04uuid\x18\x01 \x01(\t\x12\x0c\n\x04name\x18\x02 \x01(\t\"\x85\x01\n\x13\x41\x63tiveContactDetail\x12\x0c\n\x04uuid\x18\x01 \x01(\t\x12\x0c\n\x04name\x18\x02 \x01(\t\x12$\n\x03msg\x18\x03 \x01(\x0b\x32\x17.weni.flows.billing.Msg\x12,\n\x07\x63hannel\x18\x04 \x01(\x0b\x32\x1b.weni.flows.billing.Channel*\"\n\tDirection\x12\t\n\x05INPUT\x10\x00\x12\n\n\x06OUTPUT\x10\x01\x32\xba\x01\n\x07\x42illing\x12R\n\x05Total\x12\".weni.flows.billing.BillingRequest\x1a#.weni.flows.billing.BillingResponse\"\x00\x12[\n\x08\x44\x65tailed\x12\".weni.flows.billing.BillingRequest\x1a\'.weni.flows.billing.ActiveContactDetail\"\x00\x30\x01\x62\x06proto3'
   ,
   dependencies=[google_dot_protobuf_dot_timestamp__pb2.DESCRIPTOR,])
 
 _DIRECTION = _descriptor.EnumDescriptor(
   name='Direction',
-  full_name='weni.rapidpro.billing.Direction',
+  full_name='weni.flows.billing.Direction',
   filename=None,
   file=DESCRIPTOR,
   create_key=_descriptor._internal_create_key,
@@ -45,8 +45,8 @@ _DIRECTION = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   serialized_options=None,
-  serialized_start=582,
-  serialized_end=616,
+  serialized_start=514,
+  serialized_end=548,
 )
 _sym_db.RegisterEnumDescriptor(_DIRECTION)
 
@@ -58,30 +58,30 @@ OUTPUT = 1
 
 _BILLINGREQUEST = _descriptor.Descriptor(
   name='BillingRequest',
-  full_name='weni.rapidpro.billing.BillingRequest',
+  full_name='weni.flows.billing.BillingRequest',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   create_key=_descriptor._internal_create_key,
   fields=[
     _descriptor.FieldDescriptor(
-      name='org_uuid', full_name='weni.rapidpro.billing.BillingRequest.org_uuid', index=0,
+      name='org_uuid', full_name='weni.flows.billing.BillingRequest.org_uuid', index=0,
       number=1, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=b"".decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
     _descriptor.FieldDescriptor(
-      name='before', full_name='weni.rapidpro.billing.BillingRequest.before', index=1,
-      number=2, type=11, cpp_type=10, label=1,
-      has_default_value=False, default_value=None,
+      name='before', full_name='weni.flows.billing.BillingRequest.before', index=1,
+      number=2, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
     _descriptor.FieldDescriptor(
-      name='after', full_name='weni.rapidpro.billing.BillingRequest.after', index=2,
-      number=3, type=11, cpp_type=10, label=1,
-      has_default_value=False, default_value=None,
+      name='after', full_name='weni.flows.billing.BillingRequest.after', index=2,
+      number=3, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
@@ -97,21 +97,21 @@ _BILLINGREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=100,
-  serialized_end=221,
+  serialized_start=97,
+  serialized_end=162,
 )
 
 
 _BILLINGRESPONSE = _descriptor.Descriptor(
   name='BillingResponse',
-  full_name='weni.rapidpro.billing.BillingResponse',
+  full_name='weni.flows.billing.BillingResponse',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   create_key=_descriptor._internal_create_key,
   fields=[
     _descriptor.FieldDescriptor(
-      name='active_contacts', full_name='weni.rapidpro.billing.BillingResponse.active_contacts', index=0,
+      name='active_contacts', full_name='weni.flows.billing.BillingResponse.active_contacts', index=0,
       number=1, type=5, cpp_type=1, label=1,
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
@@ -129,42 +129,42 @@ _BILLINGRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=223,
-  serialized_end=265,
+  serialized_start=164,
+  serialized_end=206,
 )
 
 
 _MSG = _descriptor.Descriptor(
   name='Msg',
-  full_name='weni.rapidpro.billing.Msg',
+  full_name='weni.flows.billing.Msg',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   create_key=_descriptor._internal_create_key,
   fields=[
     _descriptor.FieldDescriptor(
-      name='uuid', full_name='weni.rapidpro.billing.Msg.uuid', index=0,
+      name='uuid', full_name='weni.flows.billing.Msg.uuid', index=0,
       number=1, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=b"".decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
     _descriptor.FieldDescriptor(
-      name='text', full_name='weni.rapidpro.billing.Msg.text', index=1,
+      name='text', full_name='weni.flows.billing.Msg.text', index=1,
       number=2, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=b"".decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
     _descriptor.FieldDescriptor(
-      name='sent_on', full_name='weni.rapidpro.billing.Msg.sent_on', index=2,
+      name='sent_on', full_name='weni.flows.billing.Msg.sent_on', index=2,
       number=3, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
     _descriptor.FieldDescriptor(
-      name='direction', full_name='weni.rapidpro.billing.Msg.direction', index=3,
+      name='direction', full_name='weni.flows.billing.Msg.direction', index=3,
       number=4, type=14, cpp_type=8, label=1,
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
@@ -182,28 +182,28 @@ _MSG = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=268,
-  serialized_end=399,
+  serialized_start=209,
+  serialized_end=337,
 )
 
 
 _CHANNEL = _descriptor.Descriptor(
   name='Channel',
-  full_name='weni.rapidpro.billing.Channel',
+  full_name='weni.flows.billing.Channel',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   create_key=_descriptor._internal_create_key,
   fields=[
     _descriptor.FieldDescriptor(
-      name='uuid', full_name='weni.rapidpro.billing.Channel.uuid', index=0,
+      name='uuid', full_name='weni.flows.billing.Channel.uuid', index=0,
       number=1, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=b"".decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
     _descriptor.FieldDescriptor(
-      name='name', full_name='weni.rapidpro.billing.Channel.name', index=1,
+      name='name', full_name='weni.flows.billing.Channel.name', index=1,
       number=2, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=b"".decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
@@ -221,42 +221,42 @@ _CHANNEL = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=401,
-  serialized_end=438,
+  serialized_start=339,
+  serialized_end=376,
 )
 
 
 _ACTIVECONTACTDETAIL = _descriptor.Descriptor(
   name='ActiveContactDetail',
-  full_name='weni.rapidpro.billing.ActiveContactDetail',
+  full_name='weni.flows.billing.ActiveContactDetail',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   create_key=_descriptor._internal_create_key,
   fields=[
     _descriptor.FieldDescriptor(
-      name='uuid', full_name='weni.rapidpro.billing.ActiveContactDetail.uuid', index=0,
+      name='uuid', full_name='weni.flows.billing.ActiveContactDetail.uuid', index=0,
       number=1, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=b"".decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
     _descriptor.FieldDescriptor(
-      name='name', full_name='weni.rapidpro.billing.ActiveContactDetail.name', index=1,
+      name='name', full_name='weni.flows.billing.ActiveContactDetail.name', index=1,
       number=2, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=b"".decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
     _descriptor.FieldDescriptor(
-      name='msg', full_name='weni.rapidpro.billing.ActiveContactDetail.msg', index=2,
+      name='msg', full_name='weni.flows.billing.ActiveContactDetail.msg', index=2,
       number=3, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
     _descriptor.FieldDescriptor(
-      name='channel', full_name='weni.rapidpro.billing.ActiveContactDetail.channel', index=3,
+      name='channel', full_name='weni.flows.billing.ActiveContactDetail.channel', index=3,
       number=4, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
@@ -274,12 +274,10 @@ _ACTIVECONTACTDETAIL = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=441,
-  serialized_end=580,
+  serialized_start=379,
+  serialized_end=512,
 )
 
-_BILLINGREQUEST.fields_by_name['before'].message_type = google_dot_protobuf_dot_timestamp__pb2._TIMESTAMP
-_BILLINGREQUEST.fields_by_name['after'].message_type = google_dot_protobuf_dot_timestamp__pb2._TIMESTAMP
 _MSG.fields_by_name['sent_on'].message_type = google_dot_protobuf_dot_timestamp__pb2._TIMESTAMP
 _MSG.fields_by_name['direction'].enum_type = _DIRECTION
 _ACTIVECONTACTDETAIL.fields_by_name['msg'].message_type = _MSG
@@ -295,35 +293,35 @@ _sym_db.RegisterFileDescriptor(DESCRIPTOR)
 BillingRequest = _reflection.GeneratedProtocolMessageType('BillingRequest', (_message.Message,), {
   'DESCRIPTOR' : _BILLINGREQUEST,
   '__module__' : 'weni.grpc.billing.grpc_gen.billing_pb2'
-  # @@protoc_insertion_point(class_scope:weni.rapidpro.billing.BillingRequest)
+  # @@protoc_insertion_point(class_scope:weni.flows.billing.BillingRequest)
   })
 _sym_db.RegisterMessage(BillingRequest)
 
 BillingResponse = _reflection.GeneratedProtocolMessageType('BillingResponse', (_message.Message,), {
   'DESCRIPTOR' : _BILLINGRESPONSE,
   '__module__' : 'weni.grpc.billing.grpc_gen.billing_pb2'
-  # @@protoc_insertion_point(class_scope:weni.rapidpro.billing.BillingResponse)
+  # @@protoc_insertion_point(class_scope:weni.flows.billing.BillingResponse)
   })
 _sym_db.RegisterMessage(BillingResponse)
 
 Msg = _reflection.GeneratedProtocolMessageType('Msg', (_message.Message,), {
   'DESCRIPTOR' : _MSG,
   '__module__' : 'weni.grpc.billing.grpc_gen.billing_pb2'
-  # @@protoc_insertion_point(class_scope:weni.rapidpro.billing.Msg)
+  # @@protoc_insertion_point(class_scope:weni.flows.billing.Msg)
   })
 _sym_db.RegisterMessage(Msg)
 
 Channel = _reflection.GeneratedProtocolMessageType('Channel', (_message.Message,), {
   'DESCRIPTOR' : _CHANNEL,
   '__module__' : 'weni.grpc.billing.grpc_gen.billing_pb2'
-  # @@protoc_insertion_point(class_scope:weni.rapidpro.billing.Channel)
+  # @@protoc_insertion_point(class_scope:weni.flows.billing.Channel)
   })
 _sym_db.RegisterMessage(Channel)
 
 ActiveContactDetail = _reflection.GeneratedProtocolMessageType('ActiveContactDetail', (_message.Message,), {
   'DESCRIPTOR' : _ACTIVECONTACTDETAIL,
   '__module__' : 'weni.grpc.billing.grpc_gen.billing_pb2'
-  # @@protoc_insertion_point(class_scope:weni.rapidpro.billing.ActiveContactDetail)
+  # @@protoc_insertion_point(class_scope:weni.flows.billing.ActiveContactDetail)
   })
 _sym_db.RegisterMessage(ActiveContactDetail)
 
@@ -331,17 +329,17 @@ _sym_db.RegisterMessage(ActiveContactDetail)
 
 _BILLING = _descriptor.ServiceDescriptor(
   name='Billing',
-  full_name='weni.rapidpro.billing.Billing',
+  full_name='weni.flows.billing.Billing',
   file=DESCRIPTOR,
   index=0,
   serialized_options=None,
   create_key=_descriptor._internal_create_key,
-  serialized_start=619,
-  serialized_end=817,
+  serialized_start=551,
+  serialized_end=737,
   methods=[
   _descriptor.MethodDescriptor(
     name='Total',
-    full_name='weni.rapidpro.billing.Billing.Total',
+    full_name='weni.flows.billing.Billing.Total',
     index=0,
     containing_service=None,
     input_type=_BILLINGREQUEST,
@@ -351,7 +349,7 @@ _BILLING = _descriptor.ServiceDescriptor(
   ),
   _descriptor.MethodDescriptor(
     name='Detailed',
-    full_name='weni.rapidpro.billing.Billing.Detailed',
+    full_name='weni.flows.billing.Billing.Detailed',
     index=1,
     containing_service=None,
     input_type=_BILLINGREQUEST,

--- a/weni/grpc/billing/grpc_gen/billing_pb2_grpc.py
+++ b/weni/grpc/billing/grpc_gen/billing_pb2_grpc.py
@@ -15,12 +15,12 @@ class BillingStub(object):
             channel: A grpc.Channel.
         """
         self.Total = channel.unary_unary(
-                '/weni.rapidpro.billing.Billing/Total',
+                '/weni.flows.billing.Billing/Total',
                 request_serializer=weni_dot_grpc_dot_billing_dot_grpc__gen_dot_billing__pb2.BillingRequest.SerializeToString,
                 response_deserializer=weni_dot_grpc_dot_billing_dot_grpc__gen_dot_billing__pb2.BillingResponse.FromString,
                 )
         self.Detailed = channel.unary_stream(
-                '/weni.rapidpro.billing.Billing/Detailed',
+                '/weni.flows.billing.Billing/Detailed',
                 request_serializer=weni_dot_grpc_dot_billing_dot_grpc__gen_dot_billing__pb2.BillingRequest.SerializeToString,
                 response_deserializer=weni_dot_grpc_dot_billing_dot_grpc__gen_dot_billing__pb2.ActiveContactDetail.FromString,
                 )
@@ -57,7 +57,7 @@ def add_BillingServicer_to_server(servicer, server):
             ),
     }
     generic_handler = grpc.method_handlers_generic_handler(
-            'weni.rapidpro.billing.Billing', rpc_method_handlers)
+            'weni.flows.billing.Billing', rpc_method_handlers)
     server.add_generic_rpc_handlers((generic_handler,))
 
 
@@ -76,7 +76,7 @@ class Billing(object):
             wait_for_ready=None,
             timeout=None,
             metadata=None):
-        return grpc.experimental.unary_unary(request, target, '/weni.rapidpro.billing.Billing/Total',
+        return grpc.experimental.unary_unary(request, target, '/weni.flows.billing.Billing/Total',
             weni_dot_grpc_dot_billing_dot_grpc__gen_dot_billing__pb2.BillingRequest.SerializeToString,
             weni_dot_grpc_dot_billing_dot_grpc__gen_dot_billing__pb2.BillingResponse.FromString,
             options, channel_credentials,
@@ -93,7 +93,7 @@ class Billing(object):
             wait_for_ready=None,
             timeout=None,
             metadata=None):
-        return grpc.experimental.unary_stream(request, target, '/weni.rapidpro.billing.Billing/Detailed',
+        return grpc.experimental.unary_stream(request, target, '/weni.flows.billing.Billing/Detailed',
             weni_dot_grpc_dot_billing_dot_grpc__gen_dot_billing__pb2.BillingRequest.SerializeToString,
             weni_dot_grpc_dot_billing_dot_grpc__gen_dot_billing__pb2.ActiveContactDetail.FromString,
             options, channel_credentials,

--- a/weni/grpc/billing/services.py
+++ b/weni/grpc/billing/services.py
@@ -6,9 +6,7 @@ from weni.grpc.billing.serializers import BillingRequestSerializer, ActiveContac
 
 class BillingService(generics.GenericService):
     def Total(self, request, context):
-        serializer = BillingRequestSerializer(
-            data=dict(org_uuid=request.org_uuid, before=request.before.ToDatetime(), after=request.after.ToDatetime())
-        )
+        serializer = BillingRequestSerializer(message=request)
         serializer.is_valid(raise_exception=True)
         org_uuid = serializer.validated_data["org_uuid"]
         before = serializer.validated_data["before"]
@@ -17,9 +15,7 @@ class BillingService(generics.GenericService):
         return BillingResponse(active_contacts=total_count)
 
     def Detailed(self, request, context):
-        serializer = BillingRequestSerializer(
-            data=dict(org_uuid=request.org_uuid, before=request.before.ToDatetime(), after=request.after.ToDatetime())
-        )
+        serializer = BillingRequestSerializer(message=request)
         serializer.is_valid(raise_exception=True)
         org_uuid = serializer.validated_data["org_uuid"]
         before = serializer.validated_data["before"]


### PR DESCRIPTION
Some problems occurred when trying to pass `Timestemp` in a gRPC request, this PR aims to adjust this.

Proto file PR: https://github.com/Ilhasoft/weni-protobuffers/pull/30
Remember, for this Pull Request to be approved, you must also approve that of weni-protobuffers.