### PR TITLE
Add None like default value to the country field on template message endpoint

### DIFF
--- a/weni/template_message/serializers.py
+++ b/weni/template_message/serializers.py
@@ -13,7 +13,7 @@ class TemplateMessageSerializers(WriteSerializer):
     content = serializers.CharField()
     name = serializers.CharField(write_only=True)
     language = serializers.CharField()
-    country = serializers.CharField()
+    country = serializers.CharField(default=None)
     variable_count = serializers.IntegerField()
     status = serializers.CharField()
 

--- a/weni/template_message/tests.py
+++ b/weni/template_message/tests.py
@@ -133,3 +133,11 @@ class CreateTemplateMessageTest(TembaPostRequestMixin, TembaTest):
 
         self.assertEquals(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertIn("channel", response_data)
+
+    def test_create_template_without_country(self):
+        data = self.request_data.copy()
+        data.pop("country")
+
+        self.request(data)
+        template_translation = TemplateTranslation.objects.first()
+        self.assertIsNone(template_translation.country.code)


### PR DESCRIPTION
Now is possible to send `None` like the value of a country field of the `Template Message` endpoint.