### PR TITLE
fix: Remove sync=False on create classifier

### DIFF
--- a/weni/grpc/classifier/serializers.py
+++ b/weni/grpc/classifier/serializers.py
@@ -23,7 +23,7 @@ class ClassifierProtoSerializer(proto_serializers.ModelProtoSerializer):
         config = dict(access_token=validated_data["access_token"])
         validated_data.pop("access_token")
 
-        return Classifier.create(config=config, **validated_data, sync=False)
+        return Classifier.create(config=config, **validated_data)
 
     class Meta:
         model = Classifier


### PR DESCRIPTION
When creating a classifier there is the option to instantly synchronize your intentions if this `sync` is `True`, and by default it is.