### PR TITLE
Add generic endpoint to create channels by ChannelType code

### DIFF
--- a/weni/grpc/channel/services.py
+++ b/weni/grpc/channel/services.py
@@ -1,8 +1,21 @@
+import json
+import re
+
+from django.http import Http404, HttpResponseBadRequest
+from django.shortcuts import get_object_or_404
+from django.contrib.sessions.middleware import SessionMiddleware
+from django.contrib.messages.middleware import MessageMiddleware
+from django.contrib.auth.models import User
 from django_grpc_framework import generics, mixins
+from django.test import RequestFactory
 
 from temba.channels.types.weniwebchat.type import WeniWebChatType
 from temba.channels.models import Channel
+from temba.orgs.models import Org
+from temba.channels.types import TYPES
+
 from weni.grpc.channel.serializers import WeniWebChatProtoSerializer, ChannelProtoSerializer
+from weni.protobuf.flows import channel_pb2
 
 
 # this class will be deprecated
@@ -23,3 +36,39 @@ class ChannelService(generics.DestroyService):
         serializer.is_valid(raise_exception=True)
         user = serializer.validated_data.get("user")
         instance.release(user)
+
+    def Create(self, request, context):
+        data: dict = None
+
+        try:
+            data = json.loads(request.data)
+        except json.decoder.JSONDecodeError:
+            raise HttpResponseBadRequest("Can't decode the `data` field")
+
+        user = get_object_or_404(User, email=request.user)
+        org = get_object_or_404(Org, uuid=request.org)
+
+        channel_type = TYPES.get(request.channeltype_code, None)
+
+        if channel_type is None:
+            raise Http404(f"No channels found with '{request.channeltype_code}' code")
+
+        url = self.create_channel(user, org, data, channel_type)
+        regex = "[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}"
+        channe_uuid = re.findall(regex, url)[0]
+
+        return channel_pb2.Channel(uuid=channe_uuid)
+
+    def create_channel(self, user: User, org: Org, data: dict, channel_type) -> str:
+        factory = RequestFactory()
+        url = f"channels/types/{channel_type.slug}/claim"
+
+        request = factory.post(url, data)
+        middleware = SessionMiddleware()
+        middleware.process_request(request)
+        request.session.save()
+
+        user._org = org
+        request.user = user
+        response = MessageMiddleware(channel_type.claim_view.as_view(channel_type=channel_type))(request)
+        return response.url

--- a/weni/grpc/channel/tests.py
+++ b/weni/grpc/channel/tests.py
@@ -1,8 +1,10 @@
+import json
+
 from django.contrib.auth import get_user_model
 from django_grpc_framework.test import RPCTransactionTestCase
 
 from temba.channels.models import Channel
-from temba.orgs.models import Org
+from temba.orgs.models import Org, OrgRole
 from temba.channels.types.weniwebchat.type import CONFIG_BASE_URL
 from weni.protobuf.flows import channel_pb2, channel_pb2_grpc
 
@@ -58,3 +60,34 @@ class ReleaseChannelServiceTest(gRPCClient, RPCTransactionTestCase):
     def test_alg(self):
         self.channel_relesase_request(uuid=self.channel_obj.uuid, user=self.user.email)
         self.assertFalse(Channel.objects.get(id=self.channel_obj.id).is_active)
+
+
+class CreateChannelServiceTest(gRPCClient, RPCTransactionTestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(username="fake@weni.ai", password="123", email="fake@weni.ai")
+        self.org = Org.objects.create(
+            name="Weni", timezone="America/Sao_Paulo", created_by=self.user, modified_by=self.user
+        )
+        self.org.add_user(self.user, OrgRole.ADMINISTRATOR)
+
+        super().setUp()
+
+    def test_create_weni_web_chat_channel(self):
+
+        data = json.dumps({"name": "test", "base_url": "https://weni.ai"})
+
+        response = self.channel_create_request(
+            user=self.user.email, org=str(self.org.uuid), data=data, channeltype_code="WWC"
+        )
+
+        channel = Channel.objects.get(uuid=response.uuid)
+        self.assertEqual(channel.name, "test")
+        self.assertEqual(channel.config.get("base_url"), "https://weni.ai")
+        self.assertEqual(channel.org, self.org)
+        self.assertEqual(channel.created_by, self.user)
+        self.assertEqual(channel.modified_by, self.user)
+        self.assertEqual(channel.channel_type, "WWC")
+
+    def channel_create_request(self, **kwargs):
+        stub = channel_pb2_grpc.ChannelControllerStub(self.channel)
+        return stub.Create(channel_pb2.ChannelCreateRequest(**kwargs))


### PR DESCRIPTION
This endpoint allows creating any channel using your `ChannelType.code`, reusing the channel's own view. Exists to avoid creating multiple endpoints unnecessarily.

Proto file PR: https://github.com/Ilhasoft/weni-protobuffers/pull/44
Remember, for this Pull Request to be approved, you must also approve that of weni-protobuffers.