### PR TITLE
Bump to 1.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+## [1.0.5] - 2021-11-12
+### Added
+- Generic endpoint to create channels by ChannelType code
+
 ## [1.0.4] - 2021-11-04
 ### Fixed
 - Removed sync=False on create classifier

--- a/poetry.lock
+++ b/poetry.lock
@@ -472,7 +472,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
 name = "weni-protobuffers"
-version = "1.2.1"
+version = "1.2.2"
 description = "Protocol Buffers for Weni Platform"
 category = "main"
 optional = false
@@ -862,8 +862,8 @@ vine = [
     {file = "vine-1.3.0.tar.gz", hash = "sha256:133ee6d7a9016f177ddeaf191c1f58421a1dcc6ee9a42c58b34bed40e1d2cd87"},
 ]
 weni-protobuffers = [
-    {file = "weni-protobuffers-1.2.1.tar.gz", hash = "sha256:97ab25a573b8194c34cfdaaf8e1f791a4c42126922cbd23746806b69dcfae289"},
-    {file = "weni_protobuffers-1.2.1-py3-none-any.whl", hash = "sha256:a09844bc888a5a061872000160192694e9237d40b409fb60eba4ef2a225379d8"},
+    {file = "weni-protobuffers-1.2.2.tar.gz", hash = "sha256:f7697e6f79d89b25d608363a5c975f428770b946888ac2104c95796613eee290"},
+    {file = "weni_protobuffers-1.2.2-py3-none-any.whl", hash = "sha256:b4b0dcb878ee3c4512ee129deda8225eb2c075200320838aa1fdd89ad9de2e63"},
 ]
 zipp = [
     {file = "zipp-3.6.0-py3-none-any.whl", hash = "sha256:9fe5ea21568a0a70e50f273397638d39b03353731e6cbbb3fd8502a33fec40bc"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "weni-rp-apps"
-version = "1.0.4"
+version = "1.0.5"
 description = "Weni apps for Rapidpro Platform"
 authors = ["jcbalmeida"]
 license = "AGPL-3.0"


### PR DESCRIPTION
Main changes:
- Add the [last PR](https://github.com/Ilhasoft/rapidpro-apps/pull/81) to `CHANGELOG.md`
- Update `weni-protobuffers` from 1.2.1 to 1.2.2