### PR TITLE
Refactor some billing endpoint nomenclatures and validate organization

### DIFF
--- a/weni/grpc/billing/serializers.py
+++ b/weni/grpc/billing/serializers.py
@@ -5,10 +5,11 @@ from rest_framework import serializers
 
 from temba.api.v2.fields import TranslatableField
 from weni.protobuf.flows import billing_pb2
+from weni.grpc.core import serializers as weni_serializers
 
 
 class BillingRequestSerializer(ProtoSerializer):
-    org_uuid = serializers.UUIDField()
+    org = weni_serializers.OrgUUIDRelatedField(write_only=True)
     before = serializers.DateTimeField()
     after = serializers.DateTimeField()
 

--- a/weni/grpc/billing/services.py
+++ b/weni/grpc/billing/services.py
@@ -1,6 +1,6 @@
 from django_grpc_framework import generics
 
-from weni.protobuf.flows.billing_pb2 import BillingResponse
+from weni.protobuf.flows.billing_pb2 import TotalResponse
 from weni.grpc.billing.queries import ActiveContactsQuery as Query
 from weni.grpc.billing.serializers import BillingRequestSerializer, ActiveContactDetailSerializer
 
@@ -13,21 +13,21 @@ class BillingService(generics.GenericService):
         serializer = self.get_serializer(message=request)
         serializer.is_valid(raise_exception=True)
 
-        org_uuid = serializer.validated_data["org_uuid"]
+        org = serializer.validated_data["org"]
         before = serializer.validated_data["before"]
         after = serializer.validated_data["after"]
-        total_count = Query.total(org_uuid, before, after)
+        total_count = Query.total(str(org.uuid), before, after)
 
-        return BillingResponse(active_contacts=total_count)
+        return TotalResponse(active_contacts=total_count)
 
     def Detailed(self, request, context):
         serializer = self.get_serializer(message=request)
         serializer.is_valid(raise_exception=True)
 
-        org_uuid = serializer.validated_data["org_uuid"]
+        org = serializer.validated_data["org"]
         before = serializer.validated_data["before"]
         after = serializer.validated_data["after"]
-        results = Query.detailed(org_uuid, before, after)
+        results = Query.detailed(str(org.uuid), before, after)
 
         for message in ActiveContactDetailSerializer(results, many=True).message:
             yield message

--- a/weni/grpc/billing/urls.py
+++ b/weni/grpc/billing/urls.py
@@ -3,4 +3,4 @@ from weni.grpc.billing.services import BillingService
 
 
 def grpc_handlers(server):
-    billing_pb2_grpc.add_BillingServicer_to_server(BillingService.as_servicer(), server)
+    billing_pb2_grpc.add_BillingControllerServicer_to_server(BillingService.as_servicer(), server)


### PR DESCRIPTION
The purpose of this PR is to adjust the billing endpoint to the `rapidpro-apps` standards

Main changes:
- Adjust BillingRequestSerializer.org field to validate UUID
- Adapting code to follow [weni-protobuffers changes](https://github.com/Ilhasoft/weni-protobuffers/pull/57)
