### PR TITLE
Fix not returning Orgs with false is_active

### DIFF
--- a/weni/grpc/org/serializers.py
+++ b/weni/grpc/org/serializers.py
@@ -27,7 +27,7 @@ class OrgProtoSerializer(proto_serializers.ModelProtoSerializer):
     class Meta:
         model = Org
         proto_class = org_pb2.Org
-        fields = ["id", "name", "uuid", "timezone", "date_format", "users"]
+        fields = ["id", "name", "uuid", "timezone", "date_format", "users", "is_active"]
 
 
 class OrgCreateProtoSerializer(proto_serializers.ModelProtoSerializer):

--- a/weni/grpc/org/services.py
+++ b/weni/grpc/org/services.py
@@ -110,9 +110,9 @@ class OrgService(AbstractService, generics.GenericService, mixins.ListModelMixin
         )
 
     def get_orgs(self, user: User):
-        admins = user.org_admins.filter(is_active=True)
-        viewers = user.org_viewers.filter(is_active=True)
-        editors = user.org_editors.filter(is_active=True)
-        surveyors = user.org_surveyors.filter(is_active=True)
+        admins = user.org_admins.all()
+        viewers = user.org_viewers.all()
+        editors = user.org_editors.all()
+        surveyors = user.org_surveyors.all()
 
         return admins.union(viewers, editors, surveyors)

--- a/weni/grpc/org/tests.py
+++ b/weni/grpc/org/tests.py
@@ -60,7 +60,7 @@ class OrgServiceTest(RPCTransactionTestCase):
         weni_org.is_active = False
         weni_org.save(update_fields=["is_active"])
 
-        self.assertEquals(self.get_orgs_count(user), 0)
+        self.assertEquals(self.get_orgs_count(user), 1)
 
         weni_org.is_active = True
         weni_org.save(update_fields=["is_active"])
@@ -145,6 +145,8 @@ class OrgServiceTest(RPCTransactionTestCase):
         self.assertEqual(response.uuid, org_uuid)
         self.assertEqual(org_timezone, response.timezone)
         self.assertEqual(org.date_format, response.date_format)
+        self.assertEqual(response.is_active, org.is_active)
+        
 
         self.assertEqual(user.id, response_user.id)
         self.assertEqual(user.email, response_user.email)


### PR DESCRIPTION
### Resume
Add 'is_active' to Org Serializer
Remove 'filter()' in get_orgs function
Change 'tests.py' to check if are returning Orgs with false is_active
Change 'tests.py' to check if is_active is ok

#### Tests:
test_list_orgs -> OK
test_retrieve_org-> OK

https://github.com/Ilhasoft/weni-protobuffers/pull/65