### PR TITLE
Fix/is active

### DIFF
--- a/weni/grpc/org/serializers.py
+++ b/weni/grpc/org/serializers.py
@@ -27,7 +27,7 @@ class OrgProtoSerializer(proto_serializers.ModelProtoSerializer):
     class Meta:
         model = Org
         proto_class = org_pb2.Org
-        fields = ["id", "name", "uuid", "timezone", "date_format", "users"]
+        fields = ["id", "name", "uuid", "timezone", "date_format", "users", "is_active"]
 
 
 class OrgCreateProtoSerializer(proto_serializers.ModelProtoSerializer):

--- a/weni/grpc/org/serializers.py
+++ b/weni/grpc/org/serializers.py
@@ -64,4 +64,5 @@ class OrgUpdateProtoSerializer(proto_serializers.ModelProtoSerializer):
             "is_multi_user",
             "is_multi_org",
             "is_suspended",
+            "is_active"
         ]

--- a/weni/grpc/org/services.py
+++ b/weni/grpc/org/services.py
@@ -110,9 +110,9 @@ class OrgService(AbstractService, generics.GenericService, mixins.ListModelMixin
         )
 
     def get_orgs(self, user: User):
-        admins = user.org_admins.filter(is_active=True)
-        viewers = user.org_viewers.filter(is_active=True)
-        editors = user.org_editors.filter(is_active=True)
-        surveyors = user.org_surveyors.filter(is_active=True)
+        admins = user.org_admins.all()
+        viewers = user.org_viewers.all()
+        editors = user.org_editors.all()
+        surveyors = user.org_surveyors.all()
 
         return admins.union(viewers, editors, surveyors)

--- a/weni/grpc/org/tests.py
+++ b/weni/grpc/org/tests.py
@@ -176,7 +176,7 @@ class OrgServiceTest(RPCTransactionTestCase):
 
     def test_update_org(self):
         org = Org.objects.first()
-        user = User.objects.first()
+        user = User.objects.get(username="weniuser")
 
         permission_error_message = f"User: {user.id} has no permission to update Org: {org.uuid}"
 
@@ -199,11 +199,14 @@ class OrgServiceTest(RPCTransactionTestCase):
             "is_multi_user": True,
             "is_multi_org": True,
             "is_suspended": True,
+            "is_active": True
         }
 
         self.stub.Update(org_pb2.OrgUpdateRequest(uuid=str(org.uuid), modified_by=user.email, **update_fields))
 
         updated_org = Org.objects.get(pk=org.pk)
+
+        self.assertEquals(update_fields.get("is_active"), updated_org.is_active)
 
         self.assertEquals(update_fields.get("name"), updated_org.name)
         self.assertNotEquals(org.name, updated_org.name)

--- a/weni/grpc/org/tests.py
+++ b/weni/grpc/org/tests.py
@@ -60,7 +60,7 @@ class OrgServiceTest(RPCTransactionTestCase):
         weni_org.is_active = False
         weni_org.save(update_fields=["is_active"])
 
-        self.assertEquals(self.get_orgs_count(user), 0)
+        self.assertEquals(self.get_orgs_count(user), 1)
 
         weni_org.is_active = True
         weni_org.save(update_fields=["is_active"])
@@ -145,6 +145,8 @@ class OrgServiceTest(RPCTransactionTestCase):
         self.assertEqual(response.uuid, org_uuid)
         self.assertEqual(org_timezone, response.timezone)
         self.assertEqual(org.date_format, response.date_format)
+        self.assertEqual(response.is_active, org.is_active)
+        
 
         self.assertEqual(user.id, response_user.id)
         self.assertEqual(user.email, response_user.email)


### PR DESCRIPTION
## Resume
In actual gRPC, the Update method of Organization class cannot change 'is_active' field, after this PR we can pass this field in OrgUpdateRequest function.

## Changes
Add 'is_active' to Update method
Fix test_update_org

## Test
test_update_org -> OK

reference: https://github.com/Ilhasoft/weni-protobuffers/pull/67