### PR TITLE
Add `permission_type` of users to org object

### DIFF
--- a/weni/grpc/org/serializers.py
+++ b/weni/grpc/org/serializers.py
@@ -20,6 +20,20 @@ class OrgProtoSerializer(proto_serializers.ModelProtoSerializer):
     users = serializers.SerializerMethodField()
     timezone = serializers.CharField()
 
+    def add_permission_to_user(self, user, permission, last_users):
+        for x in last_users:
+            if "permission_type" in x:
+                x['permission_type'].append(permission)
+                return x
+        return dict(user, **{"permission_type":[permission]})
+
+    def remove_dupes(self, mylist):
+        newlist = [mylist[0]]
+        for e in mylist:
+            if e not in newlist:
+                newlist.append(e)
+        return newlist
+
     def get_users(self, org: Org):
         values = ["id", "email", "username", "first_name", "last_name"]
 
@@ -28,14 +42,12 @@ class OrgProtoSerializer(proto_serializers.ModelProtoSerializer):
         editors = list(org.editors.all().values(*values))
         surveyors = list(org.surveyors.all().values(*values))
 
-        administrators = [dict(x, **{"permission_type":"administrator"}) for x in administrators]
-        viewers = [dict(x, **{"permission_type":"viewer"}) for x in viewers]
-        editors = [dict(x, **{"permission_type":"editor"}) for x in editors]
-        surveyors = [dict(x, **{"permission_type":"surveyor"}) for x in surveyors]
-
-        users = administrators + viewers + editors + surveyors
-
-        return users
+        users = [self.add_permission_to_user(x, "administrator", list()) for x in administrators]
+        users += [self.add_permission_to_user(x, "viewer", users) for x in viewers]
+        users += [self.add_permission_to_user(x, "editor", users) for x in editors]
+        users += [self.add_permission_to_user(x, "surveyor", users) for x in surveyors]
+    
+        return self.remove_dupes(users)
 
     class Meta:
         model = Org

--- a/weni/grpc/org/serializers.py
+++ b/weni/grpc/org/serializers.py
@@ -20,6 +20,10 @@ class OrgProtoSerializer(proto_serializers.ModelProtoSerializer):
     users = serializers.SerializerMethodField()
     timezone = serializers.CharField()
 
+    def set_user_permission(self, user: dict, permission: str) -> dict:
+        user["permission_type"] = permission
+        return user
+
     def get_users(self, org: Org):
         values = ["id", "email", "username", "first_name", "last_name"]
 
@@ -28,10 +32,11 @@ class OrgProtoSerializer(proto_serializers.ModelProtoSerializer):
         editors = list(org.editors.all().values(*values))
         surveyors = list(org.surveyors.all().values(*values))
 
-        administrators = [dict(x, **{"permission_type":"administrator"}) for x in administrators]
-        viewers = [dict(x, **{"permission_type":"viewer"}) for x in viewers]
-        editors = [dict(x, **{"permission_type":"editor"}) for x in editors]
-        surveyors = [dict(x, **{"permission_type":"surveyor"}) for x in surveyors]
+
+        administrators = list(map(lambda user: self.set_user_permission(user, "administrator"), administrators))
+        viewers = list(map(lambda user: self.set_user_permission(user, "viewer"), viewers))
+        editors = list(map(lambda user: self.set_user_permission(user, "editor"), editors))
+        surveyors = list(map(lambda user: self.set_user_permission(user, "surveyor"), surveyors))
 
         users = administrators + viewers + editors + surveyors
 

--- a/weni/grpc/org/serializers.py
+++ b/weni/grpc/org/serializers.py
@@ -21,8 +21,21 @@ class OrgProtoSerializer(proto_serializers.ModelProtoSerializer):
     timezone = serializers.CharField()
 
     def get_users(self, org: Org):
-        users = org.administrators.union(org.viewers.all(), org.editors.all(), org.surveyors.all())
-        return list(users.values("id", "email", "username", "first_name", "last_name"))
+        values = ["id", "email", "username", "first_name", "last_name"]
+
+        administrators = list(org.administrators.all().values(*values))
+        viewers = list(org.viewers.all().values(*values))
+        editors = list(org.editors.all().values(*values))
+        surveyors = list(org.surveyors.all().values(*values))
+
+        administrators = [dict(x, **{"permission_type":"administrator"}) for x in administrators]
+        viewers = [dict(x, **{"permission_type":"viewer"}) for x in viewers]
+        editors = [dict(x, **{"permission_type":"editor"}) for x in editors]
+        surveyors = [dict(x, **{"permission_type":"surveyor"}) for x in surveyors]
+
+        users = administrators + viewers + editors + surveyors
+
+        return users
 
     class Meta:
         model = Org

--- a/weni/grpc/org/serializers.py
+++ b/weni/grpc/org/serializers.py
@@ -32,7 +32,6 @@ class OrgProtoSerializer(proto_serializers.ModelProtoSerializer):
         editors = list(org.editors.all().values(*values))
         surveyors = list(org.surveyors.all().values(*values))
 
-
         administrators = list(map(lambda user: self.set_user_permission(user, "administrator"), administrators))
         viewers = list(map(lambda user: self.set_user_permission(user, "viewer"), viewers))
         editors = list(map(lambda user: self.set_user_permission(user, "editor"), editors))

--- a/weni/grpc/org/tests.py
+++ b/weni/grpc/org/tests.py
@@ -162,7 +162,7 @@ class OrgServiceTest(RPCTransactionTestCase):
         self.assertEqual(user.email, response_user.email)
         self.assertEqual(user.username, response_user.username)
 
-        self.assertEqual(response_user.permission_type, randon_permission)
+        self.assertEqual(response_user.permission_type[0], randon_permission)
 
     def test_destroy_org(self):
         org = Org.objects.last()

--- a/weni/grpc/org/tests.py
+++ b/weni/grpc/org/tests.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+import random
 
 from django.contrib.auth.models import User
 from django.conf import settings
@@ -129,7 +130,18 @@ class OrgServiceTest(RPCTransactionTestCase):
         org = Org.objects.last()
         user = User.objects.last()
 
-        org.administrators.add(user)
+        permission_types = ("administrator", "viewer", "editor", "surveyor")
+
+        randon_permission = random.choice(permission_types)
+
+        if randon_permission == "administrator":
+            org.administrators.add(user)
+        if randon_permission == "viewer":
+            org.viewers.add(user)
+        if randon_permission == "editor":
+            org.editors.add(user)
+        if randon_permission == "surveyor":
+            org.surveyors.add(user)
 
         org_uuid = str(org.uuid)
         org_timezone = str(org.timezone)
@@ -149,6 +161,8 @@ class OrgServiceTest(RPCTransactionTestCase):
         self.assertEqual(user.id, response_user.id)
         self.assertEqual(user.email, response_user.email)
         self.assertEqual(user.username, response_user.username)
+
+        self.assertEqual(response_user.permission_type, randon_permission)
 
     def test_destroy_org(self):
         org = Org.objects.last()

--- a/weni/grpc/org/tests.py
+++ b/weni/grpc/org/tests.py
@@ -132,15 +132,15 @@ class OrgServiceTest(RPCTransactionTestCase):
 
         permission_types = ("administrator", "viewer", "editor", "surveyor")
 
-        randon_permission = random.choice(permission_types)
+        random_permission = random.choice(permission_types)
 
-        if randon_permission == "administrator":
+        if random_permission == "administrator":
             org.administrators.add(user)
-        if randon_permission == "viewer":
+        if random_permission == "viewer":
             org.viewers.add(user)
-        if randon_permission == "editor":
+        if random_permission == "editor":
             org.editors.add(user)
-        if randon_permission == "surveyor":
+        if random_permission == "surveyor":
             org.surveyors.add(user)
 
         org_uuid = str(org.uuid)
@@ -162,7 +162,7 @@ class OrgServiceTest(RPCTransactionTestCase):
         self.assertEqual(user.email, response_user.email)
         self.assertEqual(user.username, response_user.username)
 
-        self.assertEqual(response_user.permission_type, randon_permission)
+        self.assertEqual(response_user.permission_type, random_permission)
 
     def test_destroy_org(self):
         org = Org.objects.last()

--- a/weni/grpc/org/tests.py
+++ b/weni/grpc/org/tests.py
@@ -162,7 +162,7 @@ class OrgServiceTest(RPCTransactionTestCase):
         self.assertEqual(user.email, response_user.email)
         self.assertEqual(user.username, response_user.username)
 
-        self.assertEqual(response_user.permission_type[0], randon_permission)
+        self.assertEqual(response_user.permission_type, randon_permission)
 
     def test_destroy_org(self):
         org = Org.objects.last()


### PR DESCRIPTION
## Resume
We need to return the permission type of users in Org, like this:
```
{
  id: 3,
  email: "wene@user.com",
  username: "weniuser",
  permission_type: "administrator"
}
```
The old code create a union between groups and return it:
```
def get_users(self, org: Org):
        users = org.administrators.union(org.viewers.all(), org.editors.all(), org.surveyors.all())
        return list(users.values("id", "email", "username", "first_name", "last_name"))
```
This solution have some problems, the union can't create a list with distiction of these groups.
QuerySet class has no method to append or union a extra value.

We have a big problem with relationship.

## Solution

So, the solution is remove abstraction of django:
```
def get_users(self, org: Org):
        values = ["id", "email", "username", "first_name", "last_name"]

        administrators = list(org.administrators.all().values(*values))
        viewers = list(org.viewers.all().values(*values))
        editors = list(org.editors.all().values(*values))
        surveyors = list(org.surveyors.all().values(*values))

        administrators = [dict(x, **{"permission_type":"administrator"}) for x in administrators]
        viewers = [dict(x, **{"permission_type":"viewer"}) for x in viewers]
        editors = [dict(x, **{"permission_type":"editor"}) for x in editors]
        surveyors = [dict(x, **{"permission_type":"surveyor"}) for x in surveyors]

        users = administrators + viewers + editors + surveyors

        return users
```

### Can we lose performance?
Anyway, we need to execute these orm to put this in a List, another solution could be found here:
https://github.com/Ilhasoft/rapidpro-apps/blob/d9444e19ad4b2bf7f95d6308614cce9f280fa4c9/weni/grpc/user/services.py#L92

but, following this solution we need to check if this user is in a group.

reference: https://github.com/Ilhasoft/weni-protobuffers/pull/72