### PR TITLE
Add Channel Cloud Whatsapp

### DIFF
--- a/weni/grpc/channel/fields.py
+++ b/weni/grpc/channel/fields.py
@@ -1,0 +1,17 @@
+import json
+
+from rest_framework import serializers
+
+
+class ConfigCharField(serializers.CharField):
+
+    def to_internal_value(self, data):
+        try:
+            return json.loads(data)
+        except json.decoder.JSONDecodeError:
+            self.fail("invalid", value=data)
+
+        
+
+    def to_representation(self, value):
+        return json.dumps(value)

--- a/weni/grpc/channel/fields.py
+++ b/weni/grpc/channel/fields.py
@@ -4,14 +4,11 @@ from rest_framework import serializers
 
 
 class ConfigCharField(serializers.CharField):
-
     def to_internal_value(self, data):
         try:
             return json.loads(data)
         except json.decoder.JSONDecodeError:
             self.fail("invalid", value=data)
-
-        
 
     def to_representation(self, value):
         return json.dumps(value)

--- a/weni/grpc/channel/serializers.py
+++ b/weni/grpc/channel/serializers.py
@@ -3,11 +3,11 @@ import json
 from django_grpc_framework import proto_serializers
 from rest_framework import serializers
 from django.core.validators import URLValidator
-from google.protobuf.empty_pb2 import Empty
 
 from temba.channels.models import Channel
 from temba.utils.fields import validate_external_url
 from temba.channels.types.weniwebchat.type import CONFIG_BASE_URL
+from temba.utils import analytics
 from weni.grpc.core import serializers as weni_serializers
 from weni.protobuf.flows import channel_pb2
 from weni.grpc.channel import fields
@@ -83,17 +83,28 @@ class ChannelWACSerializer(proto_serializers.ModelProtoSerializer):
         return json.dumps(instance)
 
     def create(self, validated_data):
-        config = validated_data.get("config")
+        channel_type = Channel.get_type_from_code(channel_type)
+        schemes = channel_type.schemes
 
-        user = validated_data["user"]
-        phone_number_id = validated_data["phone_number_id"]
+        org = validated_data.get("org")
+        name = validated_data.get("name")
+        phone_number_id = validated_data.get("phone_number_id")
+        config = validated_data.get("config", {})
+        user = validated_data.get("user")
 
-        return Channel.create(
-            validated_data["org"],
-            validated_data["user"],
-            None,
-            "WAC",
-            config=config,
-            name=config.get("wa_verified_name"),
+        channel = Channel.objects.create(
+            org=org,
+            country=None,
+            channel_type=channel_type.code,
+            name=name,
             address=phone_number_id,
+            config=config,
+            role=Channel.DEFAULT_ROLE,
+            schemes=schemes,
+            created_by=user,
+            modified_by=user,
         )
+
+        analytics.track(user, "temba.channel_created", dict(channel_type=channel_type.code))
+
+        return channel

--- a/weni/grpc/channel/serializers.py
+++ b/weni/grpc/channel/serializers.py
@@ -10,6 +10,7 @@ from temba.utils.fields import validate_external_url
 from temba.channels.types.weniwebchat.type import CONFIG_BASE_URL
 from weni.grpc.core import serializers as weni_serializers
 from weni.protobuf.flows import channel_pb2
+from weni.grpc.channel import fields
 
 
 class WeniWebChatProtoSerializer(proto_serializers.ProtoSerializer):
@@ -57,3 +58,42 @@ class ChannelProtoSerializer(proto_serializers.ModelProtoSerializer):
         proto_class = channel_pb2.Channel
         fields = ("user", "uuid", "name", "address", "config")
         read_only_fields = ("uuid", "name", "address", "config")
+
+
+class ChannelWACSerializer(proto_serializers.ModelProtoSerializer):
+    user = weni_serializers.UserEmailRelatedField(required=True, write_only=True)
+    org  = weni_serializers.OrgUUIDRelatedField(required=True, write_only=True)
+    phone_number_id = serializers.CharField(required=True, write_only=True)
+    uuid = serializers.CharField(read_only=True)
+    name = serializers.CharField(read_only=True)
+    address = serializers.CharField(read_only=True)
+    config = fields.ConfigCharField(required=True)
+
+    class Meta:
+        model = Channel
+        proto_class = channel_pb2.Channel
+        fields = ("user", "org", "phone_number_id", "uuid", "name", "address", "config")
+
+    def validate_phone_number_id(self, value):
+        if Channel.objects.filter(is_active=True, address=value).exists():
+            raise serializers.ValidationError("a Channel with that 'phone_number_id' alredy exists")
+        return value
+
+    def get_config(self, instance):
+        return json.dumps(instance)
+
+    def create(self, validated_data):
+        config = validated_data.get("config")
+
+        user = validated_data["user"]
+        phone_number_id = validated_data["phone_number_id"]
+
+        return Channel.create(
+            validated_data["org"],
+            validated_data["user"],
+            None,
+            "WAC",
+            config=config,
+            name=config.get("wa_verified_name"),
+            address=phone_number_id,
+        )

--- a/weni/grpc/channel/serializers.py
+++ b/weni/grpc/channel/serializers.py
@@ -62,7 +62,7 @@ class ChannelProtoSerializer(proto_serializers.ModelProtoSerializer):
 
 class ChannelWACSerializer(proto_serializers.ModelProtoSerializer):
     user = weni_serializers.UserEmailRelatedField(required=True, write_only=True)
-    org  = weni_serializers.OrgUUIDRelatedField(required=True, write_only=True)
+    org = weni_serializers.OrgUUIDRelatedField(required=True, write_only=True)
     phone_number_id = serializers.CharField(required=True, write_only=True)
     uuid = serializers.CharField(read_only=True)
     name = serializers.CharField(read_only=True)

--- a/weni/grpc/channel/serializers.py
+++ b/weni/grpc/channel/serializers.py
@@ -83,7 +83,7 @@ class ChannelWACSerializer(proto_serializers.ModelProtoSerializer):
         return json.dumps(instance)
 
     def create(self, validated_data):
-        channel_type = Channel.get_type_from_code(channel_type)
+        channel_type = Channel.get_type_from_code("WAC")
         schemes = channel_type.schemes
 
         org = validated_data.get("org")

--- a/weni/grpc/channel/services.py
+++ b/weni/grpc/channel/services.py
@@ -16,7 +16,7 @@ from temba.channels.models import Channel
 from temba.orgs.models import Org
 from temba.channels.types import TYPES
 
-from weni.grpc.channel.serializers import WeniWebChatProtoSerializer, ChannelProtoSerializer
+from weni.grpc.channel.serializers import WeniWebChatProtoSerializer, ChannelProtoSerializer, ChannelWACSerializer
 from weni.protobuf.flows import channel_pb2
 
 
@@ -51,6 +51,14 @@ class ChannelService(
         serializer.is_valid(raise_exception=True)
         user = serializer.validated_data.get("user")
         instance.release(user)
+
+    def CreateWAC(self, request, context):
+        serializer = ChannelWACSerializer(message=request)
+        serializer.is_valid(raise_exception=True)
+
+        serializer.save()
+
+        return serializer.message
 
     def Create(self, request, context):
         data: dict = None

--- a/weni/grpc/channel/tests.py
+++ b/weni/grpc/channel/tests.py
@@ -63,21 +63,26 @@ class CreateWACServiceTest(gRPCClient, RPCTransactionTestCase):
         self.config = {
             "wa_number": "5561995743921",
             "wa_verified_name": "Weni Test",
-            "wa_waba_id": "2433443436435435",   
+            "wa_waba_id": "2433443436435435",
             "wa_currency": "USD",
             "wa_business_id": "3443243234254322",
             "wa_message_template_namespace": "6b186dea_ds6d_44s2_b9xd_de87a12212e5",
         }
 
         super().setUp()
-    
+
     @patch("temba.channels.types.whatsapp_cloud.type.WhatsAppCloudType.activate")
     def test_create_whatsapp_cloud_channel(self, mock):
         mock.return_value = None
 
         phone_number_id = "5426423432"
 
-        channel = self.channel_create_whatsapp_cloud_request(org=str(self.org.uuid), user=self.user.email, phone_number_id=phone_number_id, config=json.dumps(self.config))
+        channel = self.channel_create_whatsapp_cloud_request(
+            org=str(self.org.uuid),
+            user=self.user.email,
+            phone_number_id=phone_number_id,
+            config=json.dumps(self.config),
+        )
 
         self.assertTrue(hasattr(channel, "uuid"))
         self.assertEqual(channel.name, self.config.get("wa_verified_name"))
@@ -90,11 +95,20 @@ class CreateWACServiceTest(gRPCClient, RPCTransactionTestCase):
 
         phone_number_id = "5426423432"
 
-        self.channel_create_whatsapp_cloud_request(org=str(self.org.uuid), user=self.user.email, phone_number_id=phone_number_id, config=json.dumps(self.config))
-        
+        self.channel_create_whatsapp_cloud_request(
+            org=str(self.org.uuid),
+            user=self.user.email,
+            phone_number_id=phone_number_id,
+            config=json.dumps(self.config),
+        )
 
-        with self.assertRaises(serializers.ValidationError): 
-            self.channel_create_whatsapp_cloud_request(org=str(self.org.uuid), user=self.user.email, phone_number_id=phone_number_id, config=json.dumps(self.config))
+        with self.assertRaises(serializers.ValidationError):
+            self.channel_create_whatsapp_cloud_request(
+                org=str(self.org.uuid),
+                user=self.user.email,
+                phone_number_id=phone_number_id,
+                config=json.dumps(self.config),
+            )
 
 
 class CreateChannelServiceTest(gRPCClient, RPCTransactionTestCase):


### PR DESCRIPTION
# Resume

This Pull Request aims to create the Channel Cloud Whatsapp endpoint.

## Additions
- Config CharField: new field class to config json data
- ChannelWACSerializer: This serializer can serializer, check config and validate phone_number_id
- CreateWAC: Service for Channel Cloud Whatsapp endpoint.
- CreateWACServiceTest: a Case Test

Reference: https://github.com/Ilhasoft/weni-protobuffers/pull/75