### PR TITLE
Add possibility of return Empty

### DIFF
--- a/weni/grpc/billing/queries.py
+++ b/weni/grpc/billing/queries.py
@@ -84,6 +84,9 @@ class MessageDetailQuery:
             .last()
         )
 
+        if not msg:
+            return None
+
         channel = Channel.objects.get(id=msg["channel"])
 
         msg["channel_id"] = channel.id

--- a/weni/grpc/billing/services.py
+++ b/weni/grpc/billing/services.py
@@ -10,6 +10,7 @@ from weni.grpc.billing.serializers import (
     MessageDetailRequestSerializer,
 )
 
+from google.protobuf import empty_pb2
 
 class BillingService(generics.GenericService):
 
@@ -49,6 +50,9 @@ class BillingService(generics.GenericService):
 
         msg = MessageDetailQuery.incoming_message(org_uuid, contact_uuid, before, after)
 
-        msg_serializer = MsgDetailSerializer(msg)
+        if not msg:
+            return empty_pb2.Empty()
 
+        msg_serializer = MsgDetailSerializer(msg)
         return msg_serializer.message
+        

--- a/weni/grpc/billing/tests.py
+++ b/weni/grpc/billing/tests.py
@@ -14,6 +14,7 @@ from weni.protobuf.flows import billing_pb2 as pb2, billing_pb2_grpc as stubs
 from weni.grpc.billing.queries import ActiveContactsQuery
 from weni.grpc.billing.serializers import BillingRequestSerializer, ActiveContactDetailSerializer
 from django_grpc_framework.test import FakeRpcError, RPCTransactionTestCase
+from google.protobuf import empty_pb2
 
 
 class ActiveContactsQueryTest(TembaTest):
@@ -252,6 +253,27 @@ class BillingServiceTest(RPCTransactionTestCase, TembaTest):
         self.assertEqual(msg.direction, result.direction)
         self.assertEqual(channel.id, result.channel_id)
         self.assertEqual(channel.channel_type, result.channel_type)
+
+    def test_message_detail_fail(self):
+        user = User.objects.create_user(username="testuser", password="123", email="test@weni.ai")
+        org = Org.objects.create(name="Temba", timezone="Africa/Kigali", created_by=user, modified_by=user)
+
+        contact = self.create_contact(f"Contact 1", phone=f"+553124826922")
+        contact.org = org
+        contact.save(update_fields=["org"])
+
+        channel = self.create_channel(channel_type="WA", name="channel_test", address="address_test", org=org)
+
+        msg = self.create_outgoing_msg(contact=contact, text="incoming message test", channel=channel, status="F")
+
+        before = tz.now()
+        after = tz.now() - tz.timedelta(minutes=1)
+
+        result = self.billing_detail_msg(
+            org_uuid=str(org.uuid), contact_uuid=str(contact.uuid), before=str(before), after=str(after)
+        )
+
+        self.assertEqual(type(result), empty_pb2.Empty)
 
     def billing_detail_msg(self, **kwargs):
         return self.stub.MessageDetail(pb2.MessageDetailRequest(**kwargs))


### PR DESCRIPTION
# Resume
Sometimes, if has not contact in a period of time, it can cause an error.

### Solution
```
if not msg:
            return empty_pb2.Empty()
```

Now it return a Empty gRPC object.