### PR TITLE
Create base classes for internal endpoints

### DIFF
--- a/weni/internal/apps.py
+++ b/weni/internal/apps.py
@@ -1,0 +1,12 @@
+from django.apps import AppConfig
+
+
+class InternalConfig(AppConfig):
+    name = "weni.internal"
+    default_auto_field = "django.db.models.BigAutoField"
+
+    def ready(self):
+        from weni.internal.urls import urlpatterns
+        from weni.utils.app_config import update_urlpatterns
+
+        update_urlpatterns(urlpatterns)

--- a/weni/internal/authenticators.py
+++ b/weni/internal/authenticators.py
@@ -1,0 +1,8 @@
+from mozilla_django_oidc.contrib.drf import OIDCAuthentication
+
+from weni.internal.backends import InternalOIDCAuthenticationBackend
+
+
+class InternalOIDCAuthentication(OIDCAuthentication):
+    def __init__(self, backend=None):
+        super().__init__(backend or InternalOIDCAuthenticationBackend())

--- a/weni/internal/backends.py
+++ b/weni/internal/backends.py
@@ -1,0 +1,37 @@
+from mozilla_django_oidc.auth import OIDCAuthenticationBackend
+from django.contrib.auth.models import Permission
+from django.contrib.contenttypes.models import ContentType
+
+
+class InternalOIDCAuthenticationBackend(OIDCAuthenticationBackend):
+    def check_module_permission(self, claims, user) -> None:
+        if claims.get("can_communicate_internally", False):
+            content_type = ContentType.objects.get_for_model(self.UserModel)
+            permission, _ = Permission.objects.get_or_create(
+                codename="can_communicate_internally",
+                name="can communicate internally",
+                content_type=content_type,
+            )
+            if not user.has_perm("auth.can_communicate_internally"):
+                user.user_permissions.add(permission)
+
+    def get_username(self, claims):
+        username = claims.get("email")
+        if username:
+            return username
+        return super().get_username(claims=claims)
+
+    def create_user(self, claims):
+        email = claims.get("email")
+        username = self.get_username(claims)
+
+        user, _ = self.UserModel.objects.get_or_create(email=email, username=username)
+
+        user.first_name = claims.get("given_name", "")
+        user.last_name = claims.get("family_name", "")
+
+        user.save()
+
+        self.check_module_permission(claims, user)
+
+        return user

--- a/weni/internal/permissions.py
+++ b/weni/internal/permissions.py
@@ -1,0 +1,6 @@
+from rest_framework import permissions
+
+
+class CanCommunicateInternally(permissions.BasePermission):
+    def has_permission(self, request, view):
+        return request.user.user_permissions.filter(codename="can_communicate_internally").exists()

--- a/weni/internal/urls.py
+++ b/weni/internal/urls.py
@@ -1,0 +1,17 @@
+"""
+Internal route registration
+
+To register a new app, import it as:
+    from weni.internal.projects.urls import urlpatterns as projects_urls
+
+After that concatenate its value in internal_urlpatterns like:
+    internal_urlpatterns += projects_urls
+"""
+
+from django.urls import path, include
+
+
+internal_urlpatterns = []
+
+
+urlpatterns = [path("internals/", include(internal_urlpatterns))]

--- a/weni/internal/views.py
+++ b/weni/internal/views.py
@@ -1,0 +1,13 @@
+from rest_framework.renderers import JSONRenderer
+from rest_framework.viewsets import GenericViewSet
+from rest_framework.permissions import IsAuthenticated
+
+from weni.internal.authenticators import InternalOIDCAuthentication
+from weni.internal.permissions import CanCommunicateInternally
+
+
+class InternalGenericViewSet(GenericViewSet):
+    authentication_classes = [InternalOIDCAuthentication]
+    permission_classes = [IsAuthenticated, CanCommunicateInternally]
+    renderer_classes = [JSONRenderer]
+    throttle_classes = []


### PR DESCRIPTION
This PR contains a base that must be shared by all views of the flows internal API

Main changes:
- Create and configure a new app called internal;
- Configure new app URLs;
- Create an OIDC Backend Inheritance to be used in a custom authentication class;
- Create a custom authentication class;
- Creates a permission class that validates whether the user can communicate internally;
- Creates a base view that all inner views should inherit.