### PR TITLE
Create serializer fields for User and Org using SlugRelatedField

### DIFF
--- a/weni/serializers/__init__.py
+++ b/weni/serializers/__init__.py
@@ -1,0 +1,1 @@
+from weni.serializers.fields import UserEmailRelatedField, OrgUUIDRelatedField

--- a/weni/serializers/fields.py
+++ b/weni/serializers/fields.py
@@ -1,0 +1,17 @@
+from django.contrib.auth import get_user_model
+from rest_framework import relations
+
+from temba.orgs.models import Org
+
+
+User = get_user_model()
+
+
+class UserEmailRelatedField(relations.SlugRelatedField):
+    def __init__(self, **kwargs):
+        super().__init__(slug_field="email", queryset=User.objects.all(), **kwargs)
+
+
+class OrgUUIDRelatedField(relations.SlugRelatedField):
+    def __init__(self, **kwargs):
+        super().__init__(slug_field="uuid", queryset=Org.objects.all(), **kwargs)


### PR DESCRIPTION
These fields are very useful and commonly used in practically all the Apps of this project, for dependency reasons I saw that it made more sense to leave them in the root of the project, instead of inside `weni.grpc.core`