### PR TITLE
Org and User APIToken internal endpoint

### DIFF
--- a/weni/internal/urls.py
+++ b/weni/internal/urls.py
@@ -12,10 +12,12 @@ from django.urls import path, include
 
 from weni.internal.orgs.urls import urlpatterns as orgs_urls
 from weni.internal.flows.urls import urlpatterns as flows_urls
+from weni.internal.users.urls import urlpatterns as users_urls
 
 
 internal_urlpatterns = []
 internal_urlpatterns += orgs_urls
 internal_urlpatterns += flows_urls
+internal_urlpatterns += users_urls
 
 urlpatterns = [path("internals/", include(internal_urlpatterns))]

--- a/weni/internal/users/serializers.py
+++ b/weni/internal/users/serializers.py
@@ -1,0 +1,8 @@
+from rest_framework import serializers
+
+from weni import serializers as weni_serializers
+
+
+class UserAPITokenSerializer(serializers.Serializer):
+    user = weni_serializers.UserEmailRelatedField(required=True)
+    org = weni_serializers.OrgUUIDRelatedField(required=True)

--- a/weni/internal/users/urls.py
+++ b/weni/internal/users/urls.py
@@ -1,0 +1,10 @@
+from rest_framework import routers
+
+from weni.internal.users.views import UserViewSet
+
+
+router = routers.DefaultRouter()
+router.register(r"users", UserViewSet, basename="users")
+
+
+urlpatterns = router.urls

--- a/weni/internal/users/views.py
+++ b/weni/internal/users/views.py
@@ -1,0 +1,30 @@
+import imp
+from typing import TYPE_CHECKING
+
+from rest_framework.decorators import action
+from rest_framework.response import Response
+from rest_framework import exceptions
+
+from weni.internal.views import InternalGenericViewSet
+from weni.internal.users.serializers import UserAPITokenSerializer
+from temba.api.models import APIToken
+
+
+if TYPE_CHECKING:
+    from rest_framework.request import Request
+
+
+class UserViewSet(InternalGenericViewSet):
+
+    @action(detail=False, methods=["GET"], url_path="api-token", serializer_class=UserAPITokenSerializer)
+    def api_token(self, request: "Request", **kwargs):
+
+        serializer = self.get_serializer(data=request.query_params)
+        serializer.is_valid(raise_exception=True)
+
+        try:
+            api_token = APIToken.objects.get(**serializer.validated_data)
+        except APIToken.DoesNotExist:
+            raise exceptions.PermissionDenied()
+
+        return Response(dict(user=api_token.user.email, org=api_token.org.uuid, api_token=api_token.key))


### PR DESCRIPTION
Adds an endpoint that allows you to retrieve the APIToken from specified User and Org.
It takes 2 query parameters
- `org`: UUID of an existing org
- `user`: Email of an existing user  

and returns a JSON containing its schema:
```json
{
  "type": "object",
  "required": ["user", "api_token", "org"],
  "properties": {
      "user": {"type": "string"},
      "org": {"type": "string"},
      "api_token": {"type": "string"}
  }
}
```