### PR TITLE
fix: set Channel Stats start date to 01/01/2000

### DIFF
--- a/weni/channel_stats/serializers.py
+++ b/weni/channel_stats/serializers.py
@@ -1,6 +1,5 @@
-from datetime import timedelta
+from datetime import timedelta, datetime
 
-from dateutil.relativedelta import relativedelta
 from django.db.models import Sum
 from django.utils import timezone
 from rest_framework import serializers
@@ -29,7 +28,7 @@ class ChannelStatsReadSerializer(ReadSerializer):
         channel = obj
 
         end_date = (timezone.now() + timedelta(days=1)).date()
-        start_date = end_date - relativedelta(months=12)
+        start_date = datetime(2000, 1, 1).date()
 
         message_stats = []
         channels = [channel]


### PR DESCRIPTION
- Previous implementation only retrieved data from a year ago to the next day and not all data.