### PR TITLE
Fix: update django url import to use re_path because of django 4

### DIFF
--- a/weni/analytics_api/urls.py
+++ b/weni/analytics_api/urls.py
@@ -1,11 +1,11 @@
-from django.conf.urls import url
+from django.urls import re_path
 from rest_framework.urlpatterns import format_suffix_patterns
 
 from .views import ContactAnalyticsEndpoint, FlowRunAnalyticsEndpoint
 
 urlpatterns = [
-    url(r"^analytics/contacts/$", ContactAnalyticsEndpoint.as_view(), name="api.v2.analytics.contacts",),
-    url(r"^analytics/flow-runs/$", FlowRunAnalyticsEndpoint.as_view(), name="api.v2.analytics.flow_runs",),
+    re_path(r"^analytics/contacts/$", ContactAnalyticsEndpoint.as_view(), name="api.v2.analytics.contacts",),
+    re_path(r"^analytics/flow-runs/$", FlowRunAnalyticsEndpoint.as_view(), name="api.v2.analytics.flow_runs",),
 ]
 
 urlpatterns = format_suffix_patterns(urlpatterns, allowed=["json", "api"])

--- a/weni/auth/urls.py
+++ b/weni/auth/urls.py
@@ -1,5 +1,4 @@
-from django.conf.urls import include, url
-from django.urls import path
+from django.urls import include, path, re_path
 
 from weni.auth.views import (
     check_user_legacy,
@@ -9,7 +8,7 @@ from weni.auth.views import (
 )
 
 urlpatterns = [
-    url(r"^oidc/", include("mozilla_django_oidc.urls")),
+    re_path(r"^oidc/", include("mozilla_django_oidc.urls")),
     path("check-user-legacy/<str:email>/", check_user_legacy, name="check-user-legacy"),
     path("weni/<uuid:organization>/authenticate", WeniAuthenticationRequestView.as_view(), name="weni-authenticate",),
     path(

--- a/weni/channel_stats/urls.py
+++ b/weni/channel_stats/urls.py
@@ -1,10 +1,10 @@
-from django.conf.urls import url
+from django.urls import re_path
 from rest_framework.urlpatterns import format_suffix_patterns
 
 from . import views
 
 urlpatterns = [
-    url(r"^channel_stats$", views.ChannelStatsEndpoint.as_view(), name="api.v2.channel_stats.channels",),
+    re_path(r"^channel_stats$", views.ChannelStatsEndpoint.as_view(), name="api.v2.channel_stats.channels",),
 ]
 
 urlpatterns = format_suffix_patterns(urlpatterns, allowed=["json", "api"])

--- a/weni/ticketer_queues/urls.py
+++ b/weni/ticketer_queues/urls.py
@@ -1,10 +1,10 @@
-from django.conf.urls import url
+from django.urls import re_path
 from rest_framework.urlpatterns import format_suffix_patterns
 
 from weni.ticketer_queues.views import TicketerQueuesEndpoint
 
 urlpatterns = [
-    url(
+    re_path(
         r"ticketer_queues$",
         TicketerQueuesEndpoint.as_view(),
         name="api.v2.ticketer_queues",


### PR DESCRIPTION
- `django.conf.urls.url()` was deprecated in Django 3.0, and is removed in Django 4.0+ and RapidPro 7.2.4 is updated with Django 4.0+