### PR TITLE
Feature/Add endpoint to suspend a org

### DIFF
--- a/weni/orgs_api/__init__.py
+++ b/weni/orgs_api/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = "weni.orgs_api.apps.OrgApiConfig"

--- a/weni/orgs_api/apps.py
+++ b/weni/orgs_api/apps.py
@@ -1,0 +1,11 @@
+from django.apps import AppConfig
+
+
+class OrgApiConfig(AppConfig):
+    name = "weni.orgs_api"
+
+    def ready(self):
+        from .urls import urlpatterns
+        from ..utils.app_config import update_urlpatterns
+
+        update_urlpatterns(urlpatterns)

--- a/weni/orgs_api/tests.py
+++ b/weni/orgs_api/tests.py
@@ -1,0 +1,75 @@
+import json
+from random import randint
+from abc import ABC, abstractmethod
+
+from django.contrib.auth.models import Group
+from django.contrib.auth.models import User
+from django.utils.http import urlencode
+from django.urls import reverse
+
+from temba.orgs.models import Org
+
+from temba.api.models import APIToken
+from temba.tests import TembaTest
+
+
+class TembaRequestMixin(ABC):
+    def reverse(self, viewname, kwargs=None, query_params=None):
+        url = reverse(viewname, kwargs=kwargs)
+
+        if query_params:
+            return "%s?%s" % (url, urlencode(query_params))
+        else:
+            return url
+
+    def request_patch(self, uuid, data):
+        url = self.reverse(self.get_url_namespace(), kwargs={"uuid": uuid})
+        token = APIToken.get_or_create(self.org, self.admin, Group.objects.get(name="Administrators"))
+
+        return self.client.patch(
+            url, HTTP_AUTHORIZATION=f"Token {token.key}", data=json.dumps(data), content_type="application/json"
+        )
+
+    @abstractmethod
+    def get_url_namespace(self):
+        ...
+
+
+class SuspendOrgTest(TembaTest, TembaRequestMixin):
+    def setUp(self):
+        User.objects.create_user(username="testuser", password="123", email="test@weni.ai")
+
+        user = User.objects.get(username="testuser")
+
+        Org.objects.create(name="Tembinha", timezone="Africa/Kigali", created_by=user, modified_by=user)
+
+        super().setUp()
+
+    def test_block_org_without_config(self):
+        org = Org.objects.get(name="Tembinha")
+
+        is_suspended = bool(randint(0, 1))
+
+        self.request_patch(uuid=org.uuid, data={"is_suspended": is_suspended})
+
+        self.assertEqual(org.config, {})
+
+        org = Org.objects.get(name="Tembinha")
+
+        self.assertEqual(org.config.get("is_suspended"), is_suspended)
+
+    def test_block_org_with_config(self):
+        org = Org.objects.get(name="Tembinha")
+        org.config["another_key"] = "test"
+        org.save()
+
+        is_suspended = bool(randint(0, 1))
+
+        self.request_patch(uuid=org.uuid, data={"is_suspended": is_suspended})
+
+        org = Org.objects.get(name="Tembinha")
+        self.assertEqual(org.config.get("is_suspended"), is_suspended)
+        self.assertEqual(org.config.get("another_key"), "test")
+
+    def get_url_namespace(self):
+        return "org-is-suspended"

--- a/weni/orgs_api/urls.py
+++ b/weni/orgs_api/urls.py
@@ -1,0 +1,7 @@
+from rest_framework import routers
+from .views import OrgViewSet
+
+router = routers.DefaultRouter()
+router.register(r"org", OrgViewSet, basename="org")
+
+urlpatterns = router.urls

--- a/weni/orgs_api/views.py
+++ b/weni/orgs_api/views.py
@@ -1,0 +1,21 @@
+from django.shortcuts import get_object_or_404
+
+from rest_framework.viewsets import GenericViewSet
+from rest_framework.decorators import action
+from rest_framework.response import Response
+
+from temba.orgs.models import Org
+
+
+class OrgViewSet(GenericViewSet):
+    permission = "orgs.org_api"
+    lookup_field = "uuid"
+
+    @action(detail=True, methods=["PATCH"])
+    def is_suspended(self, request, uuid=None):
+        org = get_object_or_404(Org, uuid=uuid)
+
+        org.config["is_suspended"] = bool(request.data.get("is_suspended"))
+        org.save()
+
+        return Response(dict(is_suspended=org.config.get("is_suspended", False)))


### PR DESCRIPTION
# Resume
This endpoints allows a adminastrator suspend an org, adding a flag to org config called `is_suspended(bool)`