### PR TITLE
Create endpoint that returns success orgs

### DIFF
--- a/weni/success_orgs/apps.py
+++ b/weni/success_orgs/apps.py
@@ -1,0 +1,11 @@
+from django.apps import AppConfig
+
+
+class SucessOrgsConfig(AppConfig):
+    name = "weni.success_orgs"
+
+    def ready(self):
+        from weni.success_orgs.urls import urlpatterns
+        from weni.utils.app_config import update_urlpatterns
+
+        update_urlpatterns(urlpatterns)

--- a/weni/success_orgs/business.py
+++ b/weni/success_orgs/business.py
@@ -1,0 +1,56 @@
+from django.db.models import Exists, OuterRef, Case, When, Value, BooleanField, F
+from django.contrib.auth import get_user_model
+
+from temba.orgs.models import Org
+from temba.classifiers.models import Classifier
+from temba.flows.models import Flow
+from temba.channels.models import Channel
+from temba.msgs.models import Msg
+
+
+User = get_user_model()
+
+
+SUCCESS_ORG_QUERIES = dict(
+    has_ia=Exists(Classifier.objects.filter(org=OuterRef("pk"), classifier_type="bothub", is_active=True)),
+    has_flows=Exists(Flow.objects.filter(org=OuterRef("pk"), is_active=True)),
+    has_channel=Exists(Channel.objects.filter(org=OuterRef("pk"), is_active=True)),
+    has_msg=Exists(Msg.objects.filter(org=OuterRef("pk"))),
+)
+
+
+class UserDoesNotExist(User.DoesNotExist):
+    pass
+
+
+def get_user_by_email(email: str) -> User:
+    try:
+        return User.objects.get(email=email)
+    except User.DoesNotExist as error:
+        raise UserDoesNotExist(error)
+
+
+def get_user_orgs(user: User):
+    return Org.objects.filter(created_by=user)
+
+
+def get_user_success_orgs(user: User):
+    user_orgs = get_user_orgs(user)
+
+    return (
+        user_orgs.annotate(user_last_login=F("created_by__last_login"))
+        .annotate(**SUCCESS_ORG_QUERIES)
+        .annotate(
+            is_success_project=Case(
+                When(has_ia=True, has_flows=True, has_channel=True, has_msg=True, then=Value(True)),
+                output_field=BooleanField(),
+                default=Value(False),
+            )
+        )
+    )
+
+
+def get_user_success_orgs_by_email(email: str):
+    user = get_user_by_email(email)
+
+    return dict(email=user.email, last_login=user.last_login, orgs=get_user_success_orgs(user))

--- a/weni/success_orgs/serializers.py
+++ b/weni/success_orgs/serializers.py
@@ -1,0 +1,17 @@
+from rest_framework import serializers
+
+
+class SuccessOrgSerializer(serializers.Serializer):
+    uuid = serializers.UUIDField()
+    name = serializers.CharField()
+    has_ia = serializers.BooleanField()
+    has_flows = serializers.BooleanField()
+    has_channel = serializers.BooleanField()
+    has_msg = serializers.BooleanField()
+    is_success_project = serializers.BooleanField()
+
+
+class UserSuccessOrgSerializer(serializers.Serializer):
+    email = serializers.EmailField()
+    last_login = serializers.CharField()
+    orgs = SuccessOrgSerializer(many=True)

--- a/weni/success_orgs/tests/test_business.py
+++ b/weni/success_orgs/tests/test_business.py
@@ -1,0 +1,21 @@
+from django.test import TestCase
+from django.contrib.auth import get_user_model
+
+from weni.success_orgs.business import UserDoesNotExist, get_user_by_email
+
+
+User = get_user_model()
+
+
+class GetUserByEmailTestCase(TestCase):
+    def setUp(self) -> None:
+        self.user_email = "fake@weni.ai"
+        self.user = User.objects.create(email=self.user_email)
+
+    def test_get_user_by_email(self):
+        user = get_user_by_email(self.user_email)
+        self.assertEqual(user.email, self.user_email)
+
+    def test_get_user_by_email_raise_does_not_exist_exception_with_wrong_email(self):
+        with self.assertRaises(UserDoesNotExist):
+            user = get_user_by_email("wrong@weni.ai")

--- a/weni/success_orgs/urls.py
+++ b/weni/success_orgs/urls.py
@@ -1,0 +1,9 @@
+from django.urls import path
+from rest_framework.urlpatterns import format_suffix_patterns
+
+from weni.success_orgs.views import SuccessOrgAPIView
+
+
+urlpatterns = [path("success_orgs", SuccessOrgAPIView.as_view(), name="api.v2.success_orgs")]
+
+urlpatterns = format_suffix_patterns(urlpatterns, allowed=["json", "api"])

--- a/weni/success_orgs/views.py
+++ b/weni/success_orgs/views.py
@@ -1,0 +1,45 @@
+from django.conf import settings
+
+from rest_framework.views import APIView
+from rest_framework.response import Response
+from rest_framework import exceptions
+from rest_framework.authentication import get_authorization_header
+
+from .business import get_user_success_orgs_by_email, UserDoesNotExist
+from .serializers import UserSuccessOrgSerializer
+
+
+class SuccessOrgAPIView(APIView):
+    def check_permissions(self, request):
+
+        auth = get_authorization_header(request).split()
+
+        if not auth:
+            raise exceptions.NotAuthenticated()
+
+        if len(auth) == 1:
+            msg = "Invalid token header. No credentials provided."
+            raise exceptions.AuthenticationFailed(msg)
+
+        elif len(auth) > 2:
+            msg = "Invalid token header. Token string should not contain spaces."
+            raise exceptions.AuthenticationFailed(msg)
+
+        if auth[1].decode() != settings.FIXED_SUPER_ACCESS_TOKEN:
+            raise exceptions.PermissionDenied(detail="")
+
+    def get(self, request, **kwargs):
+
+        user_email = request.query_params.get("email")
+
+        if user_email is None:
+            raise exceptions.ValidationError("The query param: user_email is required!")
+
+        try:
+            user_sucess_orgs = get_user_success_orgs_by_email(user_email)
+        except UserDoesNotExist:
+            raise exceptions.ValidationError(f"User with email: {user_email} does not exist")
+
+        serializer = UserSuccessOrgSerializer(user_sucess_orgs)
+
+        return Response(serializer.data)

--- a/weni/success_orgs/views.py
+++ b/weni/success_orgs/views.py
@@ -30,7 +30,7 @@ class SuccessOrgAPIView(APIView):
             raise exceptions.AuthenticationFailed(msg)
 
         if auth[1].decode() != settings.FIXED_SUPER_ACCESS_TOKEN:
-            raise exceptions.PermissionDenied(detail="")
+            raise exceptions.PermissionDenied(detail="Invalid token!")
 
     def get(self, request, **kwargs):
 

--- a/weni/success_orgs/views.py
+++ b/weni/success_orgs/views.py
@@ -10,6 +10,10 @@ from .serializers import UserSuccessOrgSerializer
 
 
 class SuccessOrgAPIView(APIView):
+
+    authentication_classes = []
+    permission_classes = []
+
     def check_permissions(self, request):
 
         auth = get_authorization_header(request).split()


### PR DESCRIPTION
Main features:
- Create a new app named `success_orgs`
- Create business rules that return successful orgs per user
- Create endpoint that returns success orgs by user email.

Usage:
```sh
curl {URL}/api/v2/success_orgs.json?email={USER_EMAIL} \
    --header "Authorization: Bearer {ACCESS_TOKEN}"
```

Return:
```json
{
	"email": "{USER_EMAIL}",
	"last_login": "2022-11-18 17:27:15.152098+00:00",
	"orgs": [{
		"uuid": "{USER_UUID}",
		"name": "Example",
		"has_ia": true,
		"has_flows": false,
		"has_channel": false,
		"has_msg": false,
		"is_success_project": false
	}]
}
