### PR TITLE
When creating a classifier syncs it synchronously

### DIFF
--- a/weni/internal/classifier/serializers.py
+++ b/weni/internal/classifier/serializers.py
@@ -22,7 +22,10 @@ class ClassifierSerializer(serializers.Serializer):
         config = dict(access_token=validated_data["access_token"])
         validated_data.pop("access_token")
 
-        return Classifier.create(config=config, **validated_data)
+        classifier = Classifier.create(config=config, sync=False, **validated_data)
+        classifier.sync()
+
+        return classifier
 
     class Meta:
         model = Classifier


### PR DESCRIPTION
When creating a Classifier it naturally already synchronizes its intentions asynchronously, this can take a while if the Celery queue is full, this PR aims to solve this problem by synchronizing the classifiers directly at the time of the creation